### PR TITLE
Create Sub Accounts When Getting Message List 

### DIFF
--- a/morpheus/app/views.py
+++ b/morpheus/app/views.py
@@ -401,7 +401,7 @@ class _UserMessagesView(UserView):
         where = Var('method') == self.request.match_info['method']
         pg_pool: BuildPgPool = self.app['pg']
         if self.session.company != '__all__':
-            company_id = await get_company_id(pg_pool, self.session.company)
+            company_id = await get_create_company_id(pg_pool, self.session.company)
             where &= Var('company_id') == company_id
 
         if message_id:

--- a/tests/test_user_display.py
+++ b/tests/test_user_display.py
@@ -388,7 +388,7 @@ async def test_many_events(cli, settings, send_email, db_conn):
 async def test_message_details_missing(cli, settings):
     r = await cli.get(modify_url(f'/user/email-test/message/123.html', settings, 'test-details'))
     assert r.status == 404, await r.text()
-    assert {'message': 'company not found'} == await r.json()
+    assert {'message': 'message not found'} == await r.json()
 
 
 async def test_message_preview(cli, settings, send_email, db_conn):


### PR DESCRIPTION
Currently, we get or create subaccounts on sending emails and SMS. But on getting message lists or message details we return 404 as no subaccount has been created if no email or SMS has been sent.

Plus tests on creating subaccounts in these scenarios.