### PR TITLE
Changing originator to our SMS number 

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -42,7 +42,7 @@ class Settings(BaseSettings):
     # Have to use a US number as the originator to send to the US
     # https://support.messagebird.com/hc/en-us/articles/208747865-United-States
     us_send_number = '15744445663'
-    tutorcruncher_number = '12048170659'  # TODO placeholder for now
+    gb_send_number = '12048170659'
 
     @validator('pg_dsn')
     def heroku_ready_pg_dsn(cls, v):

--- a/src/settings.py
+++ b/src/settings.py
@@ -42,6 +42,7 @@ class Settings(BaseSettings):
     # Have to use a US number as the originator to send to the US
     # https://support.messagebird.com/hc/en-us/articles/208747865-United-States
     us_send_number = '15744445663'
+    tutorcruncher_number = '123456789'  # TODO idk what our number is or where to find it on messagebird :(
 
     @validator('pg_dsn')
     def heroku_ready_pg_dsn(cls, v):

--- a/src/settings.py
+++ b/src/settings.py
@@ -42,7 +42,7 @@ class Settings(BaseSettings):
     # Have to use a US number as the originator to send to the US
     # https://support.messagebird.com/hc/en-us/articles/208747865-United-States
     us_send_number = '15744445663'
-    tutorcruncher_number = '123456789'  # TODO idk what our number is or where to find it on messagebird :(
+    tutorcruncher_number = '12048170659'
 
     @validator('pg_dsn')
     def heroku_ready_pg_dsn(cls, v):

--- a/src/settings.py
+++ b/src/settings.py
@@ -42,7 +42,7 @@ class Settings(BaseSettings):
     # Have to use a US number as the originator to send to the US
     # https://support.messagebird.com/hc/en-us/articles/208747865-United-States
     us_send_number = '15744445663'
-    tutorcruncher_number = '12048170659'
+    tutorcruncher_number = '12048170659'  # TODO placeholder for now
 
     @validator('pg_dsn')
     def heroku_ready_pg_dsn(cls, v):

--- a/src/worker/sms.py
+++ b/src/worker/sms.py
@@ -64,9 +64,7 @@ class SendSMS:
         self.m: SmsSendModel = m
         self.tags = list(set(self.recipient.tags + self.m.tags + [str(self.m.uid)]))
         self.messagebird: MessageBird = ctx['messagebird']
-        self.from_name = (
-            self.settings.tutorcruncher_number if self.m.country_code != 'US' else self.settings.us_send_number
-        )
+        self.from_name = self.settings.gb_send_number if self.m.country_code != 'US' else self.settings.us_send_number
 
     async def run(self):
         sms_data = await self._sms_prep()

--- a/src/worker/sms.py
+++ b/src/worker/sms.py
@@ -64,7 +64,9 @@ class SendSMS:
         self.m: SmsSendModel = m
         self.tags = list(set(self.recipient.tags + self.m.tags + [str(self.m.uid)]))
         self.messagebird: MessageBird = ctx['messagebird']
-        self.from_name = self.m.from_name if self.m.country_code != 'US' else self.settings.us_send_number
+        self.from_name = (
+            self.settings.tutorcruncher_number if self.m.country_code != 'US' else self.settings.us_send_number
+        )
 
     async def run(self):
         sms_data = await self._sms_prep()

--- a/tests/test_sms.py
+++ b/tests/test_sms.py
@@ -28,7 +28,7 @@ def test_send_message(cli, tmpdir, worker, loop):
         "to: Number(number='+447891123856', country_code='44', "
         "number_formatted='+44 7891 123856', descr=None, is_mobile=True)"
     ) in msg_file
-    assert f'\nfrom_name: {settings.tutorcruncher_number}\n' in msg_file
+    assert f'\nfrom_name: {settings.gb_send_number}\n' in msg_file
     assert '\nmessage:\nthis is a message bar\n' in msg_file
     assert '\nlength: SmsLength(length=21, parts=1)\n' in msg_file
 
@@ -325,7 +325,7 @@ def test_link_shortening(cli, tmpdir, sync_db: SyncDb, worker, loop):
     f = '69eb85e8-1504-40aa-94ff-75bb65fd8d75-447891123856.txt'
     assert str(tmpdir.listdir()[0]).endswith(f)
     msg_file = tmpdir.join(f).read()
-    assert f'\nfrom_name: {settings.tutorcruncher_number}\n' in msg_file
+    assert f'\nfrom_name: {settings.gb_send_number}\n' in msg_file
     assert '\nmessage:\nthis is a message click.example.com/l' in msg_file
     token = re.search('message click.example.com/l(.+?)\n', msg_file).groups()[0]
     assert len(token) == 12

--- a/tests/test_sms.py
+++ b/tests/test_sms.py
@@ -5,6 +5,8 @@ from foxglove.db.helpers import SyncDb
 from urllib.parse import urlencode
 from uuid import uuid4
 
+from src.main import settings
+
 
 def test_send_message(cli, tmpdir, worker, loop):
     data = {
@@ -26,7 +28,7 @@ def test_send_message(cli, tmpdir, worker, loop):
         "to: Number(number='+447891123856', country_code='44', "
         "number_formatted='+44 7891 123856', descr=None, is_mobile=True)"
     ) in msg_file
-    assert '\nfrom_name: foobar send\n' in msg_file
+    assert f'\nfrom_name: {settings.tutorcruncher_number}\n' in msg_file
     assert '\nmessage:\nthis is a message bar\n' in msg_file
     assert '\nlength: SmsLength(length=21, parts=1)\n' in msg_file
 
@@ -323,7 +325,7 @@ def test_link_shortening(cli, tmpdir, sync_db: SyncDb, worker, loop):
     f = '69eb85e8-1504-40aa-94ff-75bb65fd8d75-447891123856.txt'
     assert str(tmpdir.listdir()[0]).endswith(f)
     msg_file = tmpdir.join(f).read()
-    assert '\nfrom_name: Morpheus\n' in msg_file
+    assert f'\nfrom_name: {settings.tutorcruncher_number}\n' in msg_file
     assert '\nmessage:\nthis is a message click.example.com/l' in msg_file
     token = re.search('message click.example.com/l(.+?)\n', msg_file).groups()[0]
     assert len(token) == 12


### PR DESCRIPTION
Changes the `from_name` from the companies sms name to our TutorCruncher number. This is then used in `self.messagebird.post` where we set the originator to `from_name`