### PR TITLE
Remove pypdf for generating pdfs

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,3 +1,2 @@
 libjpeg62
 libc6
-https://mirrors.edge.kernel.org/ubuntu/pool/main/o/openssl1.1/libssl1.1_1.1.1f-1ubuntu2_amd64.deb

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ MarkupSafe==2.1.2
 phonenumbers==8.13.6
 pydantic[email]==1.9.2
 python-multipart==0.0.6
-fpdf2==2.8.3
+weasyprint==65.1
 requests==2.28.2
 starlette==0.14.2
 sentry-sdk==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ MarkupSafe==2.1.2
 phonenumbers==8.13.6
 pydantic[email]==1.9.2
 python-multipart==0.0.6
-python-pdf==0.39
+fpdf2>=3.0.0
 requests==2.28.2
 starlette==0.14.2
 sentry-sdk==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ MarkupSafe==2.1.2
 phonenumbers==8.13.6
 pydantic[email]==1.9.2
 python-multipart==0.0.6
-fpdf2>=3.0.0
+fpdf2==2.8.3
 requests==2.28.2
 starlette==0.14.2
 sentry-sdk==1.16.0

--- a/src/worker/email.py
+++ b/src/worker/email.py
@@ -36,12 +36,26 @@ STYLES_SASS = (THIS_DIR / 'extra' / 'default-styles.scss').read_text()
 email_retrying = [5, 10, 60, 600, 1800, 3600, 12 * 3600]
 
 
-def generate_pdf_from_html(html: str, page_size: str = 'A4', zoom: str = '1.0', margin_left: str = '10mm', margin_right: str = '10mm') -> bytes:
+def generate_pdf_from_html(
+    html: str, page_size: str = 'A4', zoom: str = '1.25', margin_left: str = '8mm', margin_right: str = '8mm'
+) -> bytes:
     from weasyprint import CSS
 
+    page_css = f"""
+    @page {{
+        size: {page_size};
+        margin-left: {margin_left};
+        margin-right: {margin_right};
+    }}
+    body {{
+        zoom: {zoom};
+    }}
+    """
     html_doc = HTML(string=html)
-    pdf_bytes = html_doc.write_pdf()
+    css_doc = CSS(string=page_css)
+    pdf_bytes = html_doc.write_pdf(stylesheets=[css_doc])
     return pdf_bytes
+
 
 def utcnow():
     return datetime.utcnow().replace(tzinfo=timezone.utc)

--- a/src/worker/email.py
+++ b/src/worker/email.py
@@ -10,11 +10,11 @@ from chevron import ChevronError
 from concurrent.futures import TimeoutError
 from datetime import datetime, timezone
 from foxglove import glove
+from fpdf import FPDF
 from httpcore import ReadTimeout as HttpReadTimeout
 from httpx import ConnectError, ReadTimeout
 from itertools import chain
 from pathlib import Path
-from fpdf import FPDF
 from typing import List, Optional
 
 from src.ext import ApiError
@@ -218,7 +218,9 @@ class SendEmail:
         for a in pdf_attachments:
             if a.html:
                 try:
-                    pdf_content = generate_pdf_from_html(a.html, page_size='A4', zoom='1.25', margin_left='8mm', margin_right='8mm')
+                    pdf_content = generate_pdf_from_html(
+                        a.html, page_size='A4', zoom='1.25', margin_left='8mm', margin_right='8mm'
+                    )
                 except Exception as e:
                     main_logger.warning('error generating pdf, data: %s', e)
                 else:

--- a/src/worker/email.py
+++ b/src/worker/email.py
@@ -39,19 +39,8 @@ email_retrying = [5, 10, 60, 600, 1800, 3600, 12 * 3600]
 def generate_pdf_from_html(html: str, page_size: str = 'A4', zoom: str = '1.0', margin_left: str = '10mm', margin_right: str = '10mm') -> bytes:
     from weasyprint import CSS
 
-    page_css = f"""
-    @page {{
-        size: {page_size};
-        margin-left: {margin_left};
-        margin-right: {margin_right};
-    }}
-    body {{
-        zoom: {zoom};
-    }}
-    """
     html_doc = HTML(string=html)
-    css_doc = CSS(string=page_css)
-    pdf_bytes = html_doc.write_pdf(stylesheets=[css_doc])
+    pdf_bytes = html_doc.write_pdf()
     return pdf_bytes
 
 def utcnow():

--- a/src/worker/email.py
+++ b/src/worker/email.py
@@ -37,7 +37,7 @@ email_retrying = [5, 10, 60, 600, 1800, 3600, 12 * 3600]
 
 
 def generate_pdf_from_html(
-    html: str, page_size: str = 'A4', zoom: str = '1.25', margin_left: str = '8mm', margin_right: str = '8mm'
+    html: str, page_size: str = 'A4', zoom: str = '1.0', margin_left: str = '10mm', margin_right: str = '10mm'
 ) -> bytes:
     from weasyprint import CSS
 
@@ -51,9 +51,14 @@ def generate_pdf_from_html(
         zoom: {zoom};
     }}
     """
+
     html_doc = HTML(string=html)
     css_doc = CSS(string=page_css)
-    pdf_bytes = html_doc.write_pdf(stylesheets=[css_doc])
+
+    pdf_bytes = html_doc.write_pdf(
+        stylesheets=[css_doc],
+        presentational_hints=True,
+    )
     return pdf_bytes
 
 

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -475,26 +475,26 @@ def test_invalid_mustache_body(send_email, sync_db: SyncDb):
     assert m['body'] == 'Error rendering email: unclosed tag at line 1'
 
 
-# def test_send_with_pdf(send_email, tmpdir, sync_db: SyncDb):
-#     message_id = send_email(
-#         recipients=[
-#             {
-#                 'address': 'foobar@testing.com',
-#                 'pdf_attachments': [
-#                     {'name': 'testing.pdf', 'html': '<h1>testing</h1>', 'id': 123},
-#                     {'name': 'different.pdf', 'html': '<h1>different</h1>'},
-#                 ],
-#             }
-#         ]
-#     )
-#     assert len(tmpdir.listdir()) == 1
-#     msg_file = tmpdir.join(f'{message_id}.txt').read()
-#     assert 'testing.pdf' in msg_file
-#
-#     attachments = sync_db.fetchrow_b('select * from messages where :where', where=V('external_id') == message_id)[
-#         'attachments'
-#     ]
-#     assert set(attachments) == {'123::testing.pdf', '::different.pdf'}
+def test_send_with_pdf(send_email, tmpdir, sync_db: SyncDb):
+    message_id = send_email(
+        recipients=[
+            {
+                'address': 'foobar@testing.com',
+                'pdf_attachments': [
+                    {'name': 'testing.pdf', 'html': '<h1>testing</h1>', 'id': 123},
+                    {'name': 'different.pdf', 'html': '<h1>different</h1>'},
+                ],
+            }
+        ]
+    )
+    assert len(tmpdir.listdir()) == 1
+    msg_file = tmpdir.join(f'{message_id}.txt').read()
+    assert 'testing.pdf' in msg_file
+
+    attachments = sync_db.fetchrow_b('select * from messages where :where', where=V('external_id') == message_id)[
+        'attachments'
+    ]
+    assert set(attachments) == {'123::testing.pdf', '::different.pdf'}
 
 
 def test_send_with_other_attachment(send_email, tmpdir, sync_db: SyncDb):
@@ -541,15 +541,15 @@ def test_send_with_other_attachment_pdf(send_email, tmpdir, sync_db: SyncDb):
     assert set(attachments) == {'::test_pdf.pdf', '::test_pdf_encoded.pdf'}
 
 
-# def test_pdf_not_unicode(send_email, tmpdir, cli):
-#     message_id = send_email(
-#         recipients=[
-#             {'address': 'foobar@testing.com', 'pdf_attachments': [{'name': 'testing.pdf', 'html': '<h1>binary</h1>'}]}
-#         ]
-#     )
-#     assert len(tmpdir.listdir()) == 1
-#     msg_file = tmpdir.join(f'{message_id}.txt').read()
-#     assert 'testing.pdf' in msg_file
+def test_pdf_not_unicode(send_email, tmpdir, cli):
+    message_id = send_email(
+        recipients=[
+            {'address': 'foobar@testing.com', 'pdf_attachments': [{'name': 'testing.pdf', 'html': '<h1>binary</h1>'}]}
+        ]
+    )
+    assert len(tmpdir.listdir()) == 1
+    msg_file = tmpdir.join(f'{message_id}.txt').read()
+    assert 'testing.pdf' in msg_file
 
 
 def test_pdf_empty(send_email, tmpdir, dummy_server):


### PR DESCRIPTION
**Issue number: Close #477**

### Technical description of changes
Using fpdf2 instead of pypdf.

Check

* [X] Issue number added
* [X] The original issue clearly outlines the problem solved
* [ ] Tests
* [ ] Coverage
* [X] Correct labels applied
