### PR TITLE
Missing dependency fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ ipython==8.11.0
 py==1.11.0
 setuptools==78.0.2
 openai==1.85.0
+python-dotenv==1.1.1


### PR DESCRIPTION
Added `python-dotenv==1.1.1`

Emails being sent:

<img width="1643" height="548" alt="image" src="https://github.com/user-attachments/assets/9c611723-a16d-492f-983c-f72cbf63d950" />

:rotating_light: :rotating_light: :rotating_light: :rotating_light:
 
ADD `OPENAI_API_KEY` to the Heroku config vars

Run the patch
heroku run --app <APP_NAME> -- foxglove patch add_spam_status_and_reason_to_messages --live --patch-args ':'

On prod, the app name should be `morpheus-new` but will be good to double verify as I don't have prod access.

:rotating_light: :rotating_light: :rotating_light: :rotating_light: 
