### PR TITLE
Catch spam service exception

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ filterwarnings =
 timeout = 20
 markers =
     spam: Using this marker on a test will mark the emails that test as spam.
+    spam_service_error: Using this marker on a test will mark the emails that test as spam service error.
 
 [flake8]
 max-line-length = 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -308,7 +308,11 @@ def patch_spam_detection(request, settings: Settings, glove):
 
     # Create a fake client with a mocked responses.parse method
     fake_client = AsyncMock()
-    fake_client.responses.parse.return_value = FakeResponse()
+    if 'spam_service_error' in request.keywords:
+        # This will RAISE Exception when fake_client.responses.parse() is called
+        fake_client.responses.parse.side_effect = Exception('Openai test error')
+    else:
+        fake_client.responses.parse.return_value = FakeResponse()
 
     fake_service = OpenAISpamEmailService(client=fake_client)
     fake_cache = SpamCacheService(glove.redis)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,8 +309,10 @@ def patch_spam_detection(request, settings: Settings, glove):
     # Create a fake client with a mocked responses.parse method
     fake_client = AsyncMock()
     if 'spam_service_error' in request.keywords:
-        # This will RAISE Exception when fake_client.responses.parse() is called
-        fake_client.responses.parse.side_effect = Exception('Openai test error')
+        # This will RAISE OpenAIError when fake_client.responses.parse() is called
+        from openai import OpenAIError
+
+        fake_client.responses.parse.side_effect = OpenAIError('Openai test error')
     else:
         fake_client.responses.parse.return_value = FakeResponse()
 

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1213,3 +1213,51 @@ def test_spam_logging_includes_body(cli: TestClient, sync_db: SyncDb, worker, ca
         body == 'Hi {{ recipient_first_name }}, Dont miss out on FREE MONEY! '
         'Click [here]({{ login_link }}) now! Regards, {{ company_name }}'
     )
+
+
+@pytest.mark.spam_service_error
+def test_openai_service_error(cli: TestClient, sync_db: SyncDb, worker, caplog):
+    caplog.set_level(logging.ERROR, logger='spam.email_checker')
+
+    recipients = []
+    for i in range(21):
+        recipients.append(
+            {
+                'first_name': f'User{i}',
+                'last_name': f'Last{i}',
+                'address': f'user{i}@example.org',
+                'tags': ['test'],
+            }
+        )
+
+    data = {
+        'uid': str(uuid4()),
+        'company_code': 'foobar',
+        'from_address': 'Spammer <spam@example.com>',
+        'method': 'email-test',
+        'subject_template': 'Urgent: {{ company_name }} Alert!',
+        'main_template': '{{{ main_message }}}',
+        'context': {
+            'main_message__render': 'Hi {{ recipient_first_name }},\n\nDont miss out on <b>FREE MONEY</b>! '
+            'Click [here]({{ login_link }}) now!\n\nRegards,\n{{ company_name }}',
+            'company_name': 'TestCorp',
+            'login_link': 'https://spam.example.com/click',
+        },
+        'recipients': recipients,
+    }
+
+    r = cli.post('/send/email/', json=data, headers={'Authorization': 'testing-key'})
+    assert r.status_code == 201, r.text
+    assert worker.test_run() == len(recipients)
+
+    records = [r for r in caplog.records if r.name == 'spam.email_checker' and r.levelno == logging.ERROR]
+    assert len(records) == 1
+    record = records[0]
+    assert record.reason == 'Openai test error'
+    assert record.subject == 'Urgent: TestCorp Alert!'
+    assert (
+        record.email_main_body == 'Hi {{ recipient_first_name }}, Dont miss out on FREE MONEY! '
+        'Click [here]({{ login_link }}) now! Regards, {{ company_name }}'
+    )
+    assert record.company == 'TestCorp'
+    assert record.company_code == 'foobar'


### PR DESCRIPTION
**Issue number: Close #483**

### Technical description of changes
Added error handling for OpenAI rate limiting errors. These errors occur when we exceed the current token-per-minute quota. The code now catches these exceptions and logs them to Sentry. We mark the email as not spam, whenever the spam checker fails due to llm provider errors. 

### Description for the non-dev team to understand
Better error handling

### Testing
- run the test added
- Monitor llm provider erros are logged into Sentry over time. (Difficult to test this, since, we need to simulate error from openai)

### Check
* [x] Issue number added
* [x] Tests
* [x] Help docs written and links added <-- To be done with the support team.
* [x] Coverage
* [x] Correct labels applied
