### PR TITLE
Refresh message_aggregation view by default so email analytics shows data

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -39,7 +39,10 @@ class Settings(BaseSettings):
     test_output: Path | None = None
 
     delete_old_emails: bool = False
-    update_aggregation_view: bool = False
+    # Defaults on: the email-analytics aggregation endpoint reads the message_aggregation
+    # materialized view, which is only kept current by the hourly refresh task. With this off
+    # the view goes stale and analytics shows no data.
+    update_aggregation_view: bool = True
 
     sentry_dsn: str | None = None
     logfire_token: str | None = None

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -195,6 +195,15 @@ def test_get_or_create_with_defaults_inserts(db):
     assert company.code == 'goc-defaults'
 
 
+def test_aggregation_view_enabled_by_default(monkeypatch):
+    """The aggregation refresh must run unless explicitly disabled, or analytics goes stale."""
+    from app.core.config import Settings
+
+    monkeypatch.delenv('update_aggregation_view', raising=False)
+    monkeypatch.delenv('UPDATE_AGGREGATION_VIEW', raising=False)
+    assert Settings(_env_file=None).update_aggregation_view is True
+
+
 def test_aggregation_view_disabled_setting(monkeypatch):
     """The scheduler task should no-op when settings.update_aggregation_view is False."""
     from app.core.config import settings as app_settings


### PR DESCRIPTION
## Technical description for developers

**Root cause.** The email-analytics page in TC2 calls Morpheus's `/messages/{method}/aggregation/` endpoint, which reads the `message_aggregation` **materialized view**. That view is only kept current by the hourly `update_aggregation_view` celery beat task — but the task short-circuits unless `settings.update_aggregation_view` is set, and it **defaulted to `False`**.

Since the view is created once with `CREATE MATERIALIZED VIEW IF NOT EXISTS` at bootstrap and then never refreshed, it served a frozen snapshot. As that snapshot aged past the 7/28-day windows the aggregation query reported zeros → **"Email Analytics not displaying any data"**. The message-**list** endpoints read live tables, so only the analytics aggregation was affected — matching the issue exactly.

**Fix.** Default `update_aggregation_view` to `True` so the hourly refresh runs unless explicitly disabled. The guard stays, so it can still be turned off via env if a refresh ever needs to be paused.

**Out of scope.** Switching the refresh to `REFRESH MATERIALIZED VIEW CONCURRENTLY` (would avoid the brief read-lock each hour, but needs a unique index on the view) — possible follow-up, not needed to fix the bug.

**Immediate unblock for the beta:** set `UPDATE_AGGREGATION_VIEW=True` on `tc-morpheus-beta` and run `REFRESH MATERIALIZED VIEW message_aggregation` once to backfill before this is deployed.

## Description for non-devs

The email analytics page was showing no data because the behind-the-scenes summary it reads from was never being kept up to date. This turns the hourly update back on by default, so the analytics will populate again.

Fixes tutorcruncher/TutorCruncher2#15912
