### PR TITLE
Retry Mandrill sends on all transport errors

### DIFF
--- a/app/messages/tasks.py
+++ b/app/messages/tasks.py
@@ -213,7 +213,10 @@ class SendEmail:
         defer = EMAIL_RETRYING[self.job_try - 1]
         try:
             r = Mandrill().post('messages/send.json', **data)
-        except (ConnectionError, TimeoutError, httpx.ConnectError, httpx.ReadTimeout) as e:
+        # httpx.TransportError covers all connection/timeout failures (ConnectTimeout,
+        # ReadTimeout, ConnectError, ...) — previously ConnectTimeout slipped through and
+        # the task failed without retrying, silently dropping the email.
+        except (ConnectionError, TimeoutError, httpx.TransportError) as e:
             main_logger.info(
                 'client connection error group_id=%s job_try=%s defer=%ss',
                 self.group_id,

--- a/tests/dummy_server.py
+++ b/tests/dummy_server.py
@@ -37,6 +37,8 @@ def make_handler(state: DummyState):
             subject = message.get('subject')
             if subject == '__slow__':
                 raise httpx.ReadTimeout('simulated timeout', request=request)
+            elif subject == '__connect_timeout__':
+                raise httpx.ConnectTimeout('simulated handshake timeout', request=request)
             elif subject == '__502__':
                 return _text('', 502)
             elif subject == '__500_nginx__':

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -571,6 +571,27 @@ def test_mandrill_send_client_error(sync_db: SyncDb, worker_ctx, call_send_email
     assert sync_db.fetchval('select count(*) from messages') == 0
 
 
+def test_mandrill_send_connect_timeout(sync_db: SyncDb, worker_ctx, call_send_emails, loop, worker_send_email):
+    group_id, c_id, m = call_send_emails(subject_template='__connect_timeout__')
+
+    assert sync_db.fetchval('select count(*) from messages') == 0
+    worker_ctx['job_try'] = 1
+
+    with pytest.raises(Retry) as exc_info:
+        loop.run_until_complete(
+            worker_send_email(
+                worker_ctx,
+                group_id,
+                c_id,
+                EmailRecipientModel(address='testing@recipient.com'),
+                m,
+            )
+        )
+    assert exc_info.value.defer_score == 5_000
+
+    assert sync_db.fetchval('select count(*) from messages') == 0
+
+
 def test_mandrill_send_many_errors(sync_db: SyncDb, worker_ctx, call_send_emails, loop, worker_send_email):
     group_id, c_id, m = call_send_emails()
 


### PR DESCRIPTION
## Summary

`httpx.ConnectTimeout` was not caught by the retry except clause in `SendEmail._send_mandrill` — it is neither the builtin `TimeoutError` nor a subclass of `httpx.ConnectError`/`httpx.ReadTimeout`. The celery task failed outright: no retry, and no `send_request_failed` Message row (`on_failure` only stores one for `MaxRetriesExceededError`), so the email was silently dropped.

Seen in production on 2 July ~19:58 UTC (Logfire): two sends lost to TLS handshake timeouts, while a concurrent connection-reset error (`httpx.ConnectError`) was caught, retried after 5s and succeeded.

## What we did

- Catch `httpx.TransportError` instead, which covers `ConnectTimeout` plus the other transport failures (`WriteTimeout`, `PoolTimeout`, `ReadError`, …). `ConnectError` and `ReadTimeout` are subclasses, so previously-retried cases behave the same.
- Added a `__connect_timeout__` trigger to the dummy Mandrill server and a test asserting the task retries with the 5s defer.

## Out of scope

- Recovering the two dropped emails from the 2 July incident.
- Making `on_failure` store a failed Message row for non-retry exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)