### PR TITLE
Handle unrecognised Mandrill webhook event types

### DIFF
--- a/app/messages/schemas.py
+++ b/app/messages/schemas.py
@@ -119,6 +119,7 @@ class SmsNumbersModel(BaseModel):
 class MandrillMessageStatus(str, Enum):
     send = 'send'
     deferral = 'deferral'
+    delivered = 'delivered'
     hard_bounce = 'hard_bounce'
     soft_bounce = 'soft_bounce'
     open = 'open'
@@ -194,10 +195,6 @@ class MandrillSingleWebhook(BaseWebhook):
             },
             sort_keys=sort_keys,
         )
-
-
-class MandrillWebhook(BaseModel):
-    events: list[MandrillSingleWebhook]
 
 
 class MessageBirdWebHook(BaseWebhook):

--- a/app/messages/tasks.py
+++ b/app/messages/tasks.py
@@ -26,6 +26,7 @@ from phonenumbers import (
     parse as parse_number,
 )
 from phonenumbers.geocoder import country_name_for_number, description_for_number
+from pydantic import ValidationError
 from pydf import generate_pdf
 from sqlalchemy import text
 from sqlmodel import select
@@ -41,7 +42,7 @@ from app.messages.schemas import (
     EmailRecipientModel,
     EmailSendMethod,
     EmailSendModel,
-    MandrillWebhook,
+    MandrillSingleWebhook,
     MessageBirdWebHook,
     SendMethod,
     SmsRecipientModel,
@@ -674,8 +675,6 @@ def _update_message_status(send_method: SendMethod, m: BaseWebhook, log_each: bo
 @celery_app.task(name='app.messages.tasks.update_message_status')
 def update_message_status(send_method: str, payload: dict) -> str:
     method = SendMethod(send_method)
-    from app.messages.schemas import MandrillSingleWebhook
-
     if method in (SendMethod.sms_messagebird, SendMethod.sms_test):
         m = MessageBirdWebHook.model_validate(payload)
     else:
@@ -685,17 +684,24 @@ def update_message_status(send_method: str, payload: dict) -> str:
 
 @celery_app.task(name='app.messages.tasks.update_mandrill_webhooks')
 def update_mandrill_webhooks(events: list) -> int:
-    mandrill_webhook = MandrillWebhook(events=events)
     statuses: dict[str, int] = {}
-    for m in mandrill_webhook.events:
+    for event in events:
+        # Validate each event individually so one unrecognised event type (Mandrill adds
+        # them without notice, e.g. 'delivered') doesn't fail the whole batch.
+        try:
+            m = MandrillSingleWebhook.model_validate(event)
+        except ValidationError as e:
+            main_logger.warning('ignoring invalid mandrill webhook event: %s', e)
+            statuses['ignored'] = statuses.get('ignored', 0) + 1
+            continue
         status = _update_message_status(SendMethod.email_mandrill, m, log_each=False)
         statuses[status] = statuses.get(status, 0) + 1
     main_logger.info(
         'updating %d messages: %s',
-        len(mandrill_webhook.events),
+        len(events),
         ' '.join(f'{k}={v}' for k, v in statuses.items()),
     )
-    return len(mandrill_webhook.events)
+    return len(events)
 
 
 @celery_app.task(name='app.messages.tasks.store_click')

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -193,6 +193,56 @@ def test_mandrill_webhook(cli: TestClient, send_email, sync_db: SyncDb, worker, 
     assert events[0]['status'] == 'open'
 
 
+def test_mandrill_webhook_delivered(cli: TestClient, send_email, sync_db: SyncDb, worker, loop, dummy_server, settings):
+    send_email(method='email-mandrill', recipients=[{'address': 'testing@example.org'}])
+
+    messages = [{'ts': 1969660800, 'event': 'delivered', '_id': 'mandrill-testingexampleorg', 'diag': '250 OK'}]
+
+    msg = f'https://localhost/webhook/mandrill/mandrill_events{json.dumps(messages)}'
+    sig = base64.b64encode(
+        hmac.new(settings.mandrill_webhook_key.encode(), msg=msg.encode(), digestmod=hashlib.sha1).digest()
+    )
+    r = cli.post(
+        '/webhook/mandrill/',
+        data={'mandrill_events': json.dumps(messages)},
+        headers={'X-Mandrill-Signature': sig.decode()},
+    )
+    assert r.status_code == 200, r.json()
+    assert worker.test_run() == 2
+
+    events = sync_db.fetch('select * from events')
+    assert len(events) == 1
+    assert events[0]['status'] == 'delivered'
+
+
+def test_mandrill_webhook_unknown_event(
+    cli: TestClient, send_email, sync_db: SyncDb, worker, loop, dummy_server, settings
+):
+    """Events with types we don't recognise are skipped without failing the rest of the batch."""
+    send_email(method='email-mandrill', recipients=[{'address': 'testing@example.org'}])
+
+    messages = [
+        {'ts': 1969660800, 'event': 'some_future_event', '_id': 'mandrill-testingexampleorg'},
+        {'ts': 1969660800, 'event': 'open', '_id': 'mandrill-testingexampleorg'},
+    ]
+
+    msg = f'https://localhost/webhook/mandrill/mandrill_events{json.dumps(messages)}'
+    sig = base64.b64encode(
+        hmac.new(settings.mandrill_webhook_key.encode(), msg=msg.encode(), digestmod=hashlib.sha1).digest()
+    )
+    r = cli.post(
+        '/webhook/mandrill/',
+        data={'mandrill_events': json.dumps(messages)},
+        headers={'X-Mandrill-Signature': sig.decode()},
+    )
+    assert r.status_code == 200, r.json()
+    assert worker.test_run() == 2
+
+    events = sync_db.fetch('select * from events')
+    assert len(events) == 1
+    assert events[0]['status'] == 'open'
+
+
 def test_mandrill_webhook_invalid(cli: TestClient, send_email, sync_db: SyncDb, dummy_server, settings):
     send_email(method='email-mandrill', recipients=[{'address': 'testing@example.org'}])
     messages = [{'ts': 1969660800, 'event': 'open', '_id': 'e587306</div></body><meta name=', 'foobar': ['x']}]


### PR DESCRIPTION
## Summary

Mandrill has started sending webhook events with `event: 'delivered'`, which isn't in our `MandrillMessageStatus` enum. `update_mandrill_webhooks` validated the whole batch with `MandrillWebhook(events=events)`, so a single unrecognised event failed the entire batch and no events in it were processed ([MORPHEUS-3ADA](https://tutorcruncher.sentry.io/issues/MORPHEUS-3ADA), ~12k errors since 30 June, escalating).

## What we did

- Added `delivered` to `MandrillMessageStatus` — the `message_statuses` pg enum already contains it (used by MessageBird), so events are stored as normal.
- `update_mandrill_webhooks` now validates each event individually and skips any that fail validation with a warning, so an unrecognised future event type can no longer take down a whole batch.
- Removed the now-unused `MandrillWebhook` wrapper schema and a function-level import in `update_message_status`.

## Out of scope

- Storing the top-level `diag` (SMTP response) that Mandrill sends on `delivered` events — `extra_json` only reads fields from `msg`, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)