### PR TITLE
Instrument celery with Logfire

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -24,6 +24,6 @@ def configure_logfire() -> None:
     logfire.instrument_celery()
     # Forward stdlib logging to Logfire so task-level warnings (e.g. skipped
     # unrecognised mandrill webhook events) are visible, not just stdout.
-    logging.getLogger().addHandler(logfire.LoggingHandler())
+    logging.getLogger().addHandler(logfire.LogfireLoggingHandler())
     # Per-process RSS/VMS so we can see what each web/worker process holds on the dyno
     logfire.instrument_system_metrics({'process.memory.usage': None, 'process.memory.virtual': None}, base='basic')

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -22,5 +22,8 @@ def configure_logfire() -> None:
     # Task spans on the worker (runs post-fork via worker_process_init) and publish
     # spans on the web producer, so celery activity is visible in Logfire.
     logfire.instrument_celery()
+    # Forward stdlib logging to Logfire so task-level warnings (e.g. skipped
+    # unrecognised mandrill webhook events) are visible, not just stdout.
+    logging.getLogger().addHandler(logfire.LoggingHandler())
     # Per-process RSS/VMS so we can see what each web/worker process holds on the dyno
     logfire.instrument_system_metrics({'process.memory.usage': None, 'process.memory.virtual': None}, base='basic')

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -19,5 +19,8 @@ def configure_logfire() -> None:
 
     logfire.configure(token=settings.logfire_token, service_name='morpheus')
     logfire.instrument_httpx()
+    # Task spans on the worker (runs post-fork via worker_process_init) and publish
+    # spans on the web producer, so celery activity is visible in Logfire.
+    logfire.instrument_celery()
     # Per-process RSS/VMS so we can see what each web/worker process holds on the dyno
     logfire.instrument_system_metrics({'process.memory.usage': None, 'process.memory.virtual': None}, base='basic')

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -9,6 +9,7 @@ trigger output, enum round-trip) that the framework swap could plausibly break.
 import base64
 import hashlib
 import hmac
+import logging
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -316,8 +317,18 @@ def test_configure_logfire_with_token(monkeypatch):
         def instrument_celery():
             configured['celery'] = True
 
+        class LoggingHandler(logging.NullHandler):
+            pass
+
     monkeypatch.setitem(sys.modules, 'logfire', _FakeLogfire)
-    core_logging.configure_logfire()
+    root_logger = logging.getLogger()
+    try:
+        core_logging.configure_logfire()
+        logfire_handlers = [h for h in root_logger.handlers if isinstance(h, _FakeLogfire.LoggingHandler)]
+        assert len(logfire_handlers) == 1
+    finally:
+        for handler in [h for h in root_logger.handlers if isinstance(h, _FakeLogfire.LoggingHandler)]:
+            root_logger.removeHandler(handler)
     assert configured['token'] == 'lgf_test_token'
     assert configured['httpx'] is True
     assert configured['celery'] is True

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -317,17 +317,17 @@ def test_configure_logfire_with_token(monkeypatch):
         def instrument_celery():
             configured['celery'] = True
 
-        class LoggingHandler(logging.NullHandler):
+        class LogfireLoggingHandler(logging.NullHandler):
             pass
 
     monkeypatch.setitem(sys.modules, 'logfire', _FakeLogfire)
     root_logger = logging.getLogger()
     try:
         core_logging.configure_logfire()
-        logfire_handlers = [h for h in root_logger.handlers if isinstance(h, _FakeLogfire.LoggingHandler)]
+        logfire_handlers = [h for h in root_logger.handlers if isinstance(h, _FakeLogfire.LogfireLoggingHandler)]
         assert len(logfire_handlers) == 1
     finally:
-        for handler in [h for h in root_logger.handlers if isinstance(h, _FakeLogfire.LoggingHandler)]:
+        for handler in [h for h in root_logger.handlers if isinstance(h, _FakeLogfire.LogfireLoggingHandler)]:
             root_logger.removeHandler(handler)
     assert configured['token'] == 'lgf_test_token'
     assert configured['httpx'] is True

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -312,10 +312,15 @@ def test_configure_logfire_with_token(monkeypatch):
         def instrument_system_metrics(config, base):
             configured['system_metrics'] = (config, base)
 
+        @staticmethod
+        def instrument_celery():
+            configured['celery'] = True
+
     monkeypatch.setitem(sys.modules, 'logfire', _FakeLogfire)
     core_logging.configure_logfire()
     assert configured['token'] == 'lgf_test_token'
     assert configured['httpx'] is True
+    assert configured['celery'] is True
     assert configured['system_metrics'] == (
         {'process.memory.usage': None, 'process.memory.virtual': None},
         'basic',


### PR DESCRIPTION
## Summary

Celery task activity on the new stack was invisible in Logfire — only fastapi/sqlalchemy/httpx spans were exported, so task-level failures and the `ignoring invalid mandrill webhook event` skip path (added in #501) couldn't be observed.

## What we did

- Added `logfire.instrument_celery()` to `configure_logfire()`, matching bobbin-api's setup. The worker already calls this post-fork via `worker_process_init`, so task spans are recorded per worker process; the web producer gets publish spans for `.delay()` calls.
- Attached `logfire.LogfireLoggingHandler` to the root logger in `configure_logfire()` so stdlib log lines from tasks (e.g. the skipped-webhook-event warning) reach Logfire, not just stdout. bobbin-api doesn't forward stdlib logging — this goes one step further so the warnings from #501 are observable.
- The `logfire[celery]` extra was already a dependency, so no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)