### PR TITLE
Move bootstrap DDL out of web boot; fail fast under lock (#511)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ to access a Postgres database and some really handy tools from [foxglove](https:
 
 Set up your environment, run `make install`, create your database with `make reset-db` and you're ready to go.
 
+`make reset-db` runs the schema bootstrap (`create_db_and_tables`) directly. The app does **not**
+create tables on web boot (that took ACCESS EXCLUSIVE locks on hot tables every deploy — see issue
+#511); set `db_bootstrap_on_startup=true` only if you want a boot to bootstrap. Production schema
+changes run as a deliberate one-off, e.g.
+`heroku run python -c "from app.core.database import create_db_and_tables; create_db_and_tables()"`.
+
 You can run the web worker with
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Set up your environment, run `make install`, create your database with `make res
 
 `make reset-db` runs the schema bootstrap (`create_db_and_tables`) directly. The app does **not**
 create tables on web boot (that took ACCESS EXCLUSIVE locks on hot tables every deploy — see issue
-#511); set `db_bootstrap_on_startup=true` only if you want a boot to bootstrap. Production schema
-changes run as a deliberate one-off, e.g.
+#511). Production schema changes run as a deliberate one-off, e.g.
 `heroku run python -c "from app.core.database import create_db_and_tables; create_db_and_tables()"`.
 
 You can run the web worker with

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -35,13 +35,6 @@ class Settings(BaseSettings):
     db_pool_size: int = 20
     db_max_overflow: int = 10
     db_pool_timeout: int = 30
-    # Bootstrap DDL (create_db_and_tables) runs DROP/CREATE TRIGGER on the hot messages/events
-    # tables, taking ACCESS EXCLUSIVE locks. Running it on every web boot against the shared prod
-    # DB meant one long-lived lock holder turned a dyno boot into a site-wide lock-queue dam
-    # (see issue #511). Off by default: production schema changes go through a deliberate one-off
-    # (e.g. `heroku run python -c "from app.core.database import create_db_and_tables; create_db_and_tables()"`),
-    # not implicitly on dyno start. Set true for first-time local/dev setup.
-    db_bootstrap_on_startup: bool = False
     # Celery prefork children each run ONE task at a time (worker_prefetch_multiplier=1) and open
     # one session at a time, so a child needs only a couple of connections. The web pool is per
     # process; a worker sized at the web pool would multiply (children × dynos) and, next to both

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -35,6 +35,13 @@ class Settings(BaseSettings):
     db_pool_size: int = 20
     db_max_overflow: int = 10
     db_pool_timeout: int = 30
+    # Bootstrap DDL (create_db_and_tables) runs DROP/CREATE TRIGGER on the hot messages/events
+    # tables, taking ACCESS EXCLUSIVE locks. Running it on every web boot against the shared prod
+    # DB meant one long-lived lock holder turned a dyno boot into a site-wide lock-queue dam
+    # (see issue #511). Off by default: production schema changes go through a deliberate one-off
+    # (e.g. `heroku run python -c "from app.core.database import create_db_and_tables; create_db_and_tables()"`),
+    # not implicitly on dyno start. Set true for first-time local/dev setup.
+    db_bootstrap_on_startup: bool = False
     # Celery prefork children each run ONE task at a time (worker_prefetch_multiplier=1) and open
     # one session at a time, so a child needs only a couple of connections. The web pool is per
     # process; a worker sized at the web pool would multiply (children × dynos) and, next to both

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -13,6 +13,12 @@ T = TypeVar('T', bound=SQLModel)
 BOOTSTRAP_SQL_PATH = Path(__file__).parent / 'bootstrap.sql'
 POST_BOOTSTRAP_SQL_PATH = Path(__file__).parent / 'post_bootstrap.sql'
 
+# The bootstrap DDL takes ACCESS EXCLUSIVE locks on messages/events. Scope a short lock_timeout to
+# these connections only (NOT the app engine, whose queries legitimately wait for locks) so a
+# conflicting lock holder makes bootstrap fail loudly with a traceback rather than hang for the full
+# boot deadline and dam the lock queue behind a waiting exclusive request (issue #511).
+BOOTSTRAP_LOCK_TIMEOUT = '5s'
+
 
 class DBSession(Session):
     """SQLModel session with Django-like helpers (matches tc-ai-backend's DBSession)."""
@@ -89,6 +95,7 @@ def create_db_and_tables() -> None:
     raw_conn = engine.raw_connection()
     try:
         with raw_conn.cursor() as cur:
+            cur.execute(f"SET lock_timeout = '{BOOTSTRAP_LOCK_TIMEOUT}'")
             cur.execute('CREATE EXTENSION IF NOT EXISTS btree_gin')
             cur.execute(BOOTSTRAP_SQL_PATH.read_text())
         raw_conn.commit()
@@ -98,11 +105,15 @@ def create_db_and_tables() -> None:
     # Import models so they're registered with SQLModel.metadata before create_all.
     from app.messages import models  # noqa: F401
 
-    SQLModel.metadata.create_all(engine)
+    with engine.connect() as conn:
+        conn.exec_driver_sql(f"SET lock_timeout = '{BOOTSTRAP_LOCK_TIMEOUT}'")
+        SQLModel.metadata.create_all(conn)
+        conn.commit()
 
     raw_conn = engine.raw_connection()
     try:
         with raw_conn.cursor() as cur:
+            cur.execute(f"SET lock_timeout = '{BOOTSTRAP_LOCK_TIMEOUT}'")
             cur.execute(POST_BOOTSTRAP_SQL_PATH.read_text())
         raw_conn.commit()
     finally:

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.common.api.errors import HttpMessageError, http_message_error_handler
 from app.core.config import settings
-from app.core.database import create_db_and_tables, engine
+from app.core.database import engine
 from app.core.logging import configure_logfire, configure_logging
 from app.messages.api import (
     common as common_api,
@@ -26,11 +26,9 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Bootstrap DDL is off by default in production: it takes ACCESS EXCLUSIVE locks on the hot
-    # messages/events tables, and running it on every boot turned one stuck lock holder into a
-    # site-wide outage (issue #511). Schema changes run as a deliberate one-off instead.
-    if settings.db_bootstrap_on_startup:
-        create_db_and_tables()
+    # Schema is created out-of-band (make reset-db / a deliberate one-off), never on boot: boot-time
+    # DDL took ACCESS EXCLUSIVE locks on the hot messages/events tables and turned one stuck lock
+    # holder into a site-wide outage (issue #511). Do NOT re-add create_db_and_tables() here.
     init_sentry()
     # Sync endpoints run in Starlette's thread pool (default 40 threads). Each holds one DB
     # connection for its duration, so with more threads than connections a burst leaves surplus

--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,11 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    create_db_and_tables()
+    # Bootstrap DDL is off by default in production: it takes ACCESS EXCLUSIVE locks on the hot
+    # messages/events tables, and running it on every boot turned one stuck lock holder into a
+    # site-wide outage (issue #511). Schema changes run as a deliberate one-off instead.
+    if settings.db_bootstrap_on_startup:
+        create_db_and_tables()
     init_sentry()
     # Sync endpoints run in Starlette's thread pool (default 40 threads). Each holds one DB
     # connection for its duration, so with more threads than connections a burst leaves surplus

--- a/tests/test_boot_bootstrap.py
+++ b/tests/test_boot_bootstrap.py
@@ -1,0 +1,62 @@
+"""Regression tests for issue #511: boot-time bootstrap DDL blocked messages/events.
+
+The FastAPI lifespan ran create_db_and_tables() on every web boot, which takes ACCESS EXCLUSIVE
+locks on the hot messages/events tables via DROP/CREATE TRIGGER. When a long-lived lock holder was
+present, the boot hung on the lock, dammed the whole lock queue behind the waiting exclusive
+request, and Heroku SIGKILLed the dyno at the boot deadline — a site-wide outage.
+
+These tests pin the two fixes: bootstrap is off by default in the lifespan, and when it does run it
+carries a lock_timeout so it fails loudly instead of hanging.
+"""
+
+import anyio
+import psycopg2
+import pytest
+
+from app import main as app_main
+from app.core import database as db_module
+from app.core.config import settings
+
+
+def _enter_lifespan() -> None:
+    async def _run():
+        async with app_main.lifespan(app_main.app):
+            pass
+
+    anyio.run(_run)
+
+
+def test_lifespan_skips_bootstrap_when_flag_off(monkeypatch):
+    """Default production config: the lifespan must not touch the DB before binding the port."""
+    called = []
+    monkeypatch.setattr(app_main, 'create_db_and_tables', lambda: called.append(True))
+    monkeypatch.setattr(settings, 'db_bootstrap_on_startup', False)
+    _enter_lifespan()
+    assert called == []
+
+
+def test_lifespan_runs_bootstrap_when_flag_on(monkeypatch):
+    """With the flag on (first-time/dev setup) the lifespan runs the bootstrap."""
+    called = []
+    monkeypatch.setattr(app_main, 'create_db_and_tables', lambda: called.append(True))
+    monkeypatch.setattr(settings, 'db_bootstrap_on_startup', True)
+    _enter_lifespan()
+    assert called == [True]
+
+
+@pytest.mark.timeout(15)
+def test_create_db_and_tables_fails_fast_under_conflicting_lock(monkeypatch):
+    """A conflicting ACCESS EXCLUSIVE lock on events must make bootstrap raise within the
+    lock_timeout, not hang for the whole boot deadline (issue #511)."""
+    monkeypatch.setattr(db_module, 'BOOTSTRAP_LOCK_TIMEOUT', '200ms')
+
+    blocker = db_module.engine.raw_connection()
+    try:
+        with blocker.cursor() as cur:
+            cur.execute('BEGIN')
+            cur.execute('LOCK TABLE events IN ACCESS EXCLUSIVE MODE')
+            with pytest.raises(psycopg2.errors.LockNotAvailable):
+                db_module.create_db_and_tables()
+    finally:
+        blocker.rollback()
+        blocker.close()

--- a/tests/test_boot_bootstrap.py
+++ b/tests/test_boot_bootstrap.py
@@ -12,10 +12,10 @@ carries a lock_timeout so it fails loudly instead of hanging.
 import anyio
 import psycopg2
 import pytest
+from sqlmodel import SQLModel
 
 from app import main as app_main
 from app.core import database as db_module
-from app.core.config import settings
 
 
 def _enter_lifespan() -> None:
@@ -26,22 +26,16 @@ def _enter_lifespan() -> None:
     anyio.run(_run)
 
 
-def test_lifespan_skips_bootstrap_when_flag_off(monkeypatch):
-    """Default production config: the lifespan must not touch the DB before binding the port."""
-    called = []
-    monkeypatch.setattr(app_main, 'create_db_and_tables', lambda: called.append(True))
-    monkeypatch.setattr(settings, 'db_bootstrap_on_startup', False)
-    _enter_lifespan()
-    assert called == []
+def test_lifespan_runs_no_bootstrap_ddl(monkeypatch):
+    """Web boot must not run schema DDL (issue #511). If create_db_and_tables is ever re-added to
+    the lifespan it calls SQLModel.metadata.create_all, which trips this guard however it's
+    imported. Schema is created out-of-band (make reset-db / a deliberate one-off)."""
 
+    def _fail(*args, **kwargs):
+        raise AssertionError('lifespan ran bootstrap DDL — schema must be created out-of-band (issue #511)')
 
-def test_lifespan_runs_bootstrap_when_flag_on(monkeypatch):
-    """With the flag on (first-time/dev setup) the lifespan runs the bootstrap."""
-    called = []
-    monkeypatch.setattr(app_main, 'create_db_and_tables', lambda: called.append(True))
-    monkeypatch.setattr(settings, 'db_bootstrap_on_startup', True)
+    monkeypatch.setattr(SQLModel.metadata, 'create_all', _fail)
     _enter_lifespan()
-    assert called == [True]
 
 
 @pytest.mark.timeout(15)


### PR DESCRIPTION
Fixes the code landmine behind the 2026-07-08 boot crash-loop outage (#511).

## Summary

Every web dyno boot ran `create_db_and_tables()` inside the FastAPI lifespan, which runs `DROP TRIGGER`/`CREATE TRIGGER` on `messages` and `events` — taking **ACCESS EXCLUSIVE** locks on the two hottest tables, against a shared production DB, on every deploy/restart. When a long-lived lock holder was present (a runaway `delete_old_emails` DELETE both times), the boot DDL queued for its exclusive lock; because a waiting ACCESS EXCLUSIVE request dams every lock behind it, this blocked all reads/writes on `messages`/`events`. uvicorn binds `$PORT` only after the lifespan completes, so the boot hung silently until Heroku SIGKILLed it (R10, exit 137) — and each crash-loop retry stacked another zombie DDL waiter. A code rollback didn't help because the deployed code was byte-identical.

## What we did

- **No DDL on boot** — removed the `create_db_and_tables()` call from the lifespan entirely. Nothing ever needed boot-time bootstrap: schema is created out-of-band — `make reset-db` in dev, `conftest` in tests, and a deliberate one-off in prod (`heroku run python -c "from app.core.database import create_db_and_tables; create_db_and_tables()"`) — all call the function directly. (An earlier revision gated it behind a `db_bootstrap_on_startup` setting; that flag had no real consumer and only preserved a lever to re-arm the landmine via an env var, so it was dropped.)
- **Fail fast when it does run** — scoped `lock_timeout` (`5s`) to the bootstrap connections only (NOT the app engine, whose queries legitimately wait for locks — e.g. the hourly `REFRESH MATERIALIZED VIEW`). Now the out-of-band/dev calls raise a `lock_not_available` traceback in seconds instead of hanging under a conflicting lock.
- Tests: the lifespan runs no schema DDL (guarded via `create_all`); and bootstrap raises within the timeout under a conflicting `ACCESS EXCLUSIVE` lock on `events`.

## Out of scope (follow-ups — tracked in #513)

- **RDS `idle_in_transaction_session_timeout`** — the highest-leverage systemic fix; would auto-kill a stuck lock holder regardless of the boot DDL.
- Alerting on lock waits (>30s blocked) and Heroku R10/`exit 137` crash-loops.
- `delete_old_emails` batching + anti-overlap before re-enabling (it was the lock holder that armed both incidents; pulled from beat during the incident).

Sibling service preventative fix: tutorcruncher/bobbin-api#1124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)