### PR TITLE
Fix CI publish job: build morpheus-mail with uvx, not --system pip (#515)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,10 @@ jobs:
       REDIS_URL: 'redis://localhost:6379/4'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: '3.12'
 
@@ -50,7 +50,7 @@ jobs:
       run: uv run pytest tests/ --cov=app --cov-report=xml --cov-report=term
 
     - name: codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         files: ./coverage.xml
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -67,7 +67,7 @@ jobs:
       HEROKU_APP: tc-morpheus
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: git fetch --unshallow
       - run: git switch master
       - run: git remote add heroku https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP.git
@@ -79,15 +79,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.12'
-
-      - name: install build deps
-        run: uv pip install --system setuptools wheel twine
 
       - name: stage render module under morpheus/ namespace
         working-directory: packaging/morpheus-mail
@@ -97,18 +94,20 @@ jobs:
           touch morpheus/__init__.py
 
       - name: build morpheus-mail (render submodule)
-        # Builds from a subdirectory so the root pyproject.toml (which defines the main
-        # app) doesn't get auto-applied to this distribution.
+        # Build with uvx (isolated, uv-managed Python) rather than `uv pip install --system` +
+        # setup.py: the runner's system Python is PEP 668 externally-managed, so --system installs
+        # are refused (#515). `build` reads this dir's setup.py directly; running from the
+        # subdirectory keeps the root pyproject.toml (the main app) out of this distribution.
         working-directory: packaging/morpheus-mail
-        run: python setup.py sdist bdist_wheel
+        run: uvx --from build pyproject-build --sdist --wheel
 
       - name: twine check
         working-directory: packaging/morpheus-mail
-        run: twine check dist/*
+        run: uvx twine check dist/*
 
       - name: upload to pypi
         working-directory: packaging/morpheus-mail
-        run: twine upload dist/*
+        run: uvx twine upload dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.pypi_password }}


### PR DESCRIPTION
<!-- reviewed-up-to: 049854231871c0aab7b5ba4aca3f5c0496f86a8b | verdict: APPROVED | 2026-07-10 -->
> 🔍 Reviewed up to `049854231` — **APPROVED**, 2026-07-10 (`/full_review`). Re-run after non-trivial changes.

Fixes #515.

## Problem
The `publish` job fails on tag builds at **install build deps** (`.github/workflows/main.yml`):
```
uv pip install --system setuptools wheel twine
```
`--system` targets the runner's system Python at `/usr`, which is **PEP 668 externally-managed**, so uv refuses the install and every downstream step (`setup.py` build, `twine check`, `twine upload`) never runs. Compounding it, `astral-sh/setup-uv@v3` silently ignored the `python-version: '3.12'` input (v3 has no such input), so no managed interpreter was ever provisioned — uv fell back to `/usr`.

## Fix
Build the `morpheus-mail` sdist+wheel with **`uvx --from build pyproject-build`** and run twine via **`uvx`** — isolated, uv-managed Python, no `--system`, no PEP 668 surface at all. `build` reads the package's own `setup.py` directly, and running from `packaging/morpheus-mail/` keeps the root `pyproject.toml` out of the distribution (unchanged behaviour).

## Also bundled (deprecations the same run flagged)
Node20-deprecated actions bumped to current majors:
- `actions/checkout@v4 → v5`
- `astral-sh/setup-uv@v3 → v6` (v6 accepts `python-version`, clearing the invalid-input annotation)
- `codecov/codecov-action@v4 → v5`

## Verification
A GH-runner PEP-668 failure can't be reproduced by a local pytest, so I ran the build path locally instead (the part of CI that *is* reproducible):
```
stage app/render -> packaging/morpheus-mail/morpheus/render
uvx --from build pyproject-build --sdist --wheel   # builds sdist + wheel
uvx twine check dist/*                             # PASSED (both artefacts)
```
Both artefacts build and pass `twine check`. The real proof is the next tag build; this PR makes that path viable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)