### PR TITLE
Handle Mandrill returning 400 for subaccount validation errors

### DIFF
--- a/app/messages/api/subaccounts.py
+++ b/app/messages/api/subaccounts.py
@@ -24,18 +24,20 @@ def create_subaccount(method: SendMethod, m: Optional[SubaccountModel] = None):
         return JSONResponse({'message': f'no subaccount creation required for "{method.value}"'})
     assert m is not None
 
+    # Mandrill used to return validation errors (including "already exists") as 500; it now
+    # returns them as 400 with the detail wrapped in a "Validation error: {...}" message.
+    # Accept both so the already-exists check below works across the changeover.
     r = Mandrill().post(
         'subaccounts/add.json',
         id=m.company_code,
         name=m.company_name,
-        allowed_statuses=(200, 500),
+        allowed_statuses=(200, 400, 500),
         timeout_=12,
     )
     data = r.json()
     if r.status_code == 200:
         return JSONResponse({'message': 'subaccount created'}, status_code=201)
 
-    assert r.status_code == 500, r.status_code
     if f'A subaccount with id {m.company_code} already exists' not in data.get('message', ''):
         return JSONResponse(
             {'message': f'error from mandrill: {json.dumps(data, indent=2)}'},
@@ -79,7 +81,7 @@ def delete_subaccount(method: SendMethod, m: SubaccountModel, db: DBSession = De
     if method == SendMethod.email_mandrill:
         r = Mandrill().post(
             'subaccounts/delete.json',
-            allowed_statuses=(200, 500),
+            allowed_statuses=(200, 400, 500),
             id=m.company_code,
             timeout_=12,
         )

--- a/tests/dummy_server.py
+++ b/tests/dummy_server.py
@@ -66,7 +66,18 @@ def make_handler(state: DummyState):
             if sa_id == 'broken':
                 return _json({'error': 'snap something unknown went wrong'}, 500)
             elif sa_id in state.mandrill_subaccounts:
-                return _json({'message': f'A subaccount with id {sa_id} already exists'}, 500)
+                if sa_id == 'legacy-500':
+                    # mandrill's old behaviour: validation errors as 500 with a bare message
+                    return _json({'message': f'A subaccount with id {sa_id} already exists'}, 500)
+                return _json(
+                    {
+                        'status': 'error',
+                        'code': -2,
+                        'name': 'ValidationError',
+                        'message': f'Validation error: {{"id":"A subaccount with id {sa_id} already exists"}}',
+                    },
+                    400,
+                )
             state.mandrill_subaccounts[sa_id] = data
             return _json({'message': "subaccount created (this isn't the same response as mandrill)"})
 

--- a/tests/test_aux.py
+++ b/tests/test_aux.py
@@ -54,6 +54,23 @@ def test_create_subaccount_new_few_sent(cli: Client, sync_db: SyncDb, dummy_serv
     }
     assert dummy_server.log == [
         'POST /mandrill/subaccounts/add.json > 200',
+        'POST /mandrill/subaccounts/add.json > 400',
+        'GET /mandrill/subaccounts/info.json > 200',
+    ]
+
+
+def test_create_subaccount_exists_legacy_500(cli: Client, sync_db: SyncDb, dummy_server: DummyServer):
+    data = {'company_code': 'legacy-500'}
+    r = cli.post('/create-subaccount/email-mandrill/', json=data, headers={'Authorization': 'testing-key'})
+    assert r.status_code == 201, r.text
+
+    r = cli.post('/create-subaccount/email-mandrill/', json=data, headers={'Authorization': 'testing-key'})
+    assert r.status_code == 200, r.text
+    assert r.json() == {
+        'message': 'subaccount already exists with only 42 emails sent, reuse of subaccount id permitted'
+    }
+    assert dummy_server.log == [
+        'POST /mandrill/subaccounts/add.json > 200',
         'POST /mandrill/subaccounts/add.json > 500',
         'GET /mandrill/subaccounts/info.json > 200',
     ]
@@ -71,7 +88,7 @@ def test_create_subaccount_lots(cli: TestClient, sync_db: SyncDb, dummy_server: 
     }
     assert dummy_server.log == [
         'POST /mandrill/subaccounts/add.json > 200',
-        'POST /mandrill/subaccounts/add.json > 500',
+        'POST /mandrill/subaccounts/add.json > 400',
         'GET /mandrill/subaccounts/info.json > 200',
     ]
 


### PR DESCRIPTION
## Summary

Dev was 500ing on `POST /create-subaccount/email-mandrill/` for existing subaccounts. Root cause: Mandrill now returns validation errors (including "a subaccount with id X already exists") as HTTP 400 `ValidationError` with the detail wrapped in `Validation error: {...}`, where it historically returned 500 with a bare message. The endpoint only allowed `(200, 500)`, so the client raised `ApiError` and the request 500ed before reaching the already-exists handling.

## What we did

- `create_subaccount`: allow 400 alongside 500 from `subaccounts/add.json` and drop the `assert status == 500`. The already-exists substring check matches both the old and new message shapes, so the existing flow (check `sent_total` → 200 reuse-permitted / 409) is unchanged.
- `delete_subaccount`: allow 400 from `subaccounts/delete.json` for the same reason.
- Dummy server now simulates Mandrill's new 400 response shape, with a `legacy-500` id keeping the old shape covered; tests updated for both.

Related TC2 change (making `REUSE_EXISTING_MANDRILL_SUB_ACCOUNTS` env-configurable) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)