### PR TITLE
Return zero spend from billing view for companies that have never sent

### DIFF
--- a/app/messages/api/sms.py
+++ b/app/messages/api/sms.py
@@ -8,7 +8,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import func
 from sqlmodel import select
 
-from app.common.api.errors import HTTP400, HTTP404, HTTP409
+from app.common.api.errors import HTTP400, HTTP409
 from app.common.auth import AdminAuth
 from app.core.database import DBSession, get_db
 from app.messages.models import Company, Message, MessageGroup, SmsSendMethod
@@ -42,13 +42,13 @@ def sms_billing_view(
     data: dict = Body(None),
     db: DBSession = Depends(get_db),
 ):
-    company = db.exec(select(Company).where(Company.code == company_code)).first()
-    if not company:
-        raise HTTP404('company not found')
     if not data or 'start' not in data or 'end' not in data:
         raise HTTP400('request body must include "start" and "end" dates')
     start = datetime.strptime(data['start'], '%Y-%m-%d')
     end = datetime.strptime(data['end'], '%Y-%m-%d')
+    # Company rows are created lazily on first send, so a code TC2 knows about may have no row yet;
+    # "never sent" means zero spend, not 404. Resolve after validation so a bad request writes nothing.
+    company = _get_or_create_company(db, company_code)
     spend = _get_sms_spend(db, company_id=company.id, method=method.value, start=start, end=end)  # ty:ignore[invalid-argument-type]
     return {
         'company': company_code,

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -111,15 +111,17 @@ def test_email_send_duplicate_uid_returns_409(cli: TestClient, send_email):
     assert r.json() == {'message': f'Send group with id "{uid}" already exists\n'}
 
 
-def test_sms_billing_company_not_found(cli: TestClient):
+def test_sms_billing_unknown_company_zero_spend(cli: TestClient):
+    # Deliberate departure from legacy parity (issue #524): an unknown company code means
+    # "never sent" and returns zero spend instead of 404, matching the other company-code endpoints.
     r = cli.request(
         'GET',
         '/billing/sms-test/no-such-company/',
         json={'start': '2032-01-01', 'end': '2032-12-31'},
         headers={'Authorization': 'testing-key'},
     )
-    assert r.status_code == 404, r.text
-    assert r.json() == {'message': 'company not found'}
+    assert r.status_code == 200, r.text
+    assert r.json() == {'company': 'no-such-company', 'start': '2032-01-01', 'end': '2032-12-31', 'spend': 0}
 
 
 def test_mandrill_webhook_invalid_signature(cli: TestClient):

--- a/tests/test_sms.py
+++ b/tests/test_sms.py
@@ -3,7 +3,10 @@ from datetime import datetime, timedelta
 from urllib.parse import urlencode
 from uuid import uuid4
 
+from sqlmodel import select
+
 from app.core.config import settings
+from app.messages.models import Company
 from tests.conftest import SyncDb
 
 
@@ -461,3 +464,25 @@ def test_sms_billing(cli, send_sms, send_webhook, sync_db):
     )
     assert r.status_code == 200, r.text
     assert {'company': 'billing-test', 'start': start, 'end': end, 'spend': 0.048} == r.json()
+
+
+def test_sms_billing_never_sent_company(cli, db):
+    start = (datetime.utcnow() - timedelta(days=5)).strftime('%Y-%m-%d')
+    end = (datetime.utcnow() + timedelta(days=5)).strftime('%Y-%m-%d')
+    r = cli.request(
+        'GET',
+        '/billing/sms-test/never-sent/',
+        json=dict(start=start, end=end),
+        headers={'Authorization': 'testing-key'},
+    )
+    assert r.status_code == 200, r.text
+    assert {'company': 'never-sent', 'start': start, 'end': end, 'spend': 0} == r.json()
+    # the company row is created on first sight, matching the other company-code endpoints
+    assert db.exec(select(Company).where(Company.code == 'never-sent')).one() is not None
+
+
+def test_sms_billing_bad_request_creates_no_company(cli, db):
+    r = cli.request('GET', '/billing/sms-test/never-sent/', headers={'Authorization': 'testing-key'})
+    assert r.status_code == 400, r.text
+    assert r.json() == {'message': 'request body must include "start" and "end" dates'}
+    assert db.exec(select(Company).where(Company.code == 'never-sent')).first() is None


### PR DESCRIPTION
**Issue number: Close #524**

### Technical description of changes

`Company` rows are only created on first send. So a company code that has never sent a message has no row, and `sms_billing_view` 404'd on it. Every other company-code endpoint (`message_list`, `message_aggregation`, `message_details`, both send views) resolves the code with `_get_or_create_company` instead, and `message_list` already returns `spend: 0` for a company it has never seen.

TC2 fetches spend for every branch of an agency to build one billing page, so a single never-used branch made the whole page error until that branch sent something.

Fix: resolve the company with `_get_or_create_company` (race-safe) after body validation, matching the other endpoints. Never-sent codes now return `spend: 0`; a malformed request still writes nothing. The parity test asserting the old 404 is updated on purpose, and TC2 already falls back to zero on `spend`, so nothing else changes.

### Description for the non-dev team to understand

Billing pages errored for agencies with a new branch that had not sent anything yet. Such branches now count as zero spend and the page loads normally.

#### Recreation Steps

`GET /billing/sms-messagebird/<code>/` with a never-sent code: was `404 company not found`, now `200` with `"spend": 0`.

### Manual testing required

None, covered by tests.

### Checklist

- [x] Issue number added
- [x] The original issue clearly outlines the problem solved
- [x] Tests
- [x] Coverage
- [x] `make lint` passes


---

### Manual Testing

Local UAT against a real server and database. Every case has terminal evidence: the request, the response, and a database check.

- [x] **Phase 1: Billing endpoint behavior**
  <details><summary>Test cases</summary>

  - [x] 1.1 A company with sends returns the correct spend for the date window. Three seeded messages at 0.012 in July gave spend 0.036. A message outside the window was excluded.
    <details><summary>Screenshots</summary>

    <img width="820" src="https://github.com/tutorcruncher/morpheus/raw/pr-screenshots/uat-525-2026-07-23-p1-1-valid-company-spend.png">
    </details>

  - [x] 1.2 Date window filtering works. A June window returned only the June message (spend 0.5). A window before any sends returned spend 0.
    <details><summary>Screenshots</summary>

    <img width="820" src="https://github.com/tutorcruncher/morpheus/raw/pr-screenshots/uat-525-2026-07-23-p1-2-window-filter.png">
    </details>

  - [x] 1.3 Core fix: an unknown company code returns 200 with spend 0 instead of 404, and the company row is created. Database checked before (0 rows) and after (1 row, 0 messages).
    <details><summary>Screenshots</summary>

    <img width="820" src="https://github.com/tutorcruncher/morpheus/raw/pr-screenshots/uat-525-2026-07-23-p1-3-unknown-company-creates-row.png">
    </details>

  - [x] 1.4 Repeat call for the now-created company is idempotent: 200 with spend 0 and still exactly one company row.
    <details><summary>Screenshots</summary>

    <img width="820" src="https://github.com/tutorcruncher/morpheus/raw/pr-screenshots/uat-525-2026-07-23-p1-4-repeat-idempotent.png">
    </details>

  </details>

- [x] **Phase 2: Guards**
  <details><summary>Test cases</summary>

  - [x] 2.1 Missing start/end dates: 400 with a clear message, and no company row is created. Validation runs before company resolution.
    <details><summary>Screenshots</summary>

    <img width="820" src="https://github.com/tutorcruncher/morpheus/raw/pr-screenshots/uat-525-2026-07-23-p2-1-bad-request-400.png">
    </details>

  - [x] 2.2 Invalid auth key: 403, and no company row is created.
    <details><summary>Screenshots</summary>

    <img width="820" src="https://github.com/tutorcruncher/morpheus/raw/pr-screenshots/uat-525-2026-07-23-p2-2-bad-auth.png">
    </details>

  </details>

Note: spend values can show float artifacts (e.g. 0.036000000000000004). This exists on master (float cost column summed in SQL) and is handled by the consumer, which wraps the value in Decimal.




