### PR TITLE
Match subaccount deletion on the exact company code, not a prefix

### DIFF
--- a/app/messages/api/subaccounts.py
+++ b/app/messages/api/subaccounts.py
@@ -58,13 +58,16 @@ def create_subaccount(method: SendMethod, m: Optional[SubaccountModel] = None):
 def delete_subaccount(method: SendMethod, m: SubaccountModel, db: DBSession = Depends(get_db)):
     """Delete an existing subaccount with Mandrill.
 
-    Deletes companies whose code starts with ``m.company_code`` along with their child rows.
+    Company codes are either the bare subaccount code or ``<code>:<branch_id>``, so match on the
+    part before the first colon. A plain prefix match must NOT be used here: it also matches
+    companies whose code merely starts with ``m.company_code`` (deleting ``simply-learn`` used to
+    wipe ``simply-learning-tuition:7664``'s entire message history).
     The production schema was built by the legacy migrations with ON DELETE RESTRICT on
     messages.company_id / message_groups.company_id, so we cannot rely on a CASCADE from
     companies — we delete messages (events/links cascade off messages) then message_groups
     then companies, matching the old delete order.
     """
-    company_ids = db.exec(select(Company.id).where(Company.code.like(m.company_code + '%'))).all()  # ty:ignore[unresolved-attribute]
+    company_ids = db.exec(select(Company.id).where(func.split_part(Company.code, ':', 1) == m.company_code)).all()
     m_count = g_count = 0
     if company_ids:
         m_count = db.exec(select(func.count()).select_from(Message).where(Message.company_id.in_(company_ids))).one()  # ty:ignore[unresolved-attribute]

--- a/tests/test_aux.py
+++ b/tests/test_aux.py
@@ -184,6 +184,25 @@ def test_delete_subaccount_multiple_branches(cli: TestClient, sync_db: SyncDb, d
     assert sync_db.fetchval('select count(*) from companies') == 1
 
 
+def test_delete_subaccount_does_not_match_longer_codes(
+    cli: TestClient, sync_db: SyncDb, send_email, dummy_server: DummyServer
+):
+    """Deleting 'simply-learn' must not touch 'simply-learning-tuition' (code-prefix collision)."""
+    send_email(company_code='simply-learn:1')
+    send_email(company_code='simply-learn')
+    send_email(company_code='simply-learning-tuition:7664')
+    assert sync_db.fetchval('select count(*) from companies') == 3
+    assert sync_db.fetchval('select count(*) from messages') == 3
+
+    data = {'company_code': 'simply-learn'}
+    r = cli.post('/delete-subaccount/email-test/', json=data, headers={'Authorization': 'testing-key'})
+    assert r.status_code == 200, r.text
+    assert r.json() == {'message': 'deleted_messages=2 deleted_message_groups=2'}
+
+    assert sync_db.fetchval('select code from companies') == 'simply-learning-tuition:7664'
+    assert sync_db.fetchval('select count(*) from messages') == 1
+
+
 def test_delete_subaccount_wrong_response(cli: TestClient, sync_db: SyncDb, dummy_server: DummyServer):
     data = {'company_code': 'broken1'}
     _create_test_subaccount(cli, data)


### PR DESCRIPTION
## Technical description for developers

`delete_subaccount` selected companies to delete with `Company.code.like(m.company_code + '%')`. Company codes are `<subaccount_code>:<branch_id>` (or historically the bare code), so the prefix match was meant to catch an agency's per-branch companies — but it also matches **any other agency** whose subaccount code merely starts with the same string.

This is how TutorCruncher2 issue tutorcruncher/TutorCruncher2#17579 happened: the nightly terminated-agency deletion job deleted the subaccount `simply-learn` on 2026-08-23 17:15 UTC, and the `LIKE 'simply-learn%'` match swept up `simply-learning-tuition:7664` — deleting Simply Learning Tuition's entire message history (messages, message groups and company row). Their "Related Emails" cards have been empty for anything sent before that moment ever since. Logfire shows other huge collateral deletions in the same job's nightly runs (e.g. 219,071 messages against 32 message groups on 27 Aug), and codes like `tuition`, `etutor`, `upskill` and `ace-tutors` have been deleted recently, so other agencies are likely affected too.

The fix matches on `split_part(code, ':', 1) = :company_code`, which covers both the bare code and every `<code>:<branch>` variant exactly, with no prefix semantics (and no `LIKE` wildcard-injection surface from `%`/`_` in codes). The V1 morpheus had the same bug (`code like $1 || '%'`), so this is long-latent, not a V2 regression.

- Rewrote the company selection in `delete_subaccount` and updated its docstring.
- Added `test_delete_subaccount_does_not_match_longer_codes`: deleting `simply-learn` removes `simply-learn` and `simply-learn:1` (with their messages) but leaves `simply-learning-tuition:7664` untouched.

## Description for non-devs

When a closed-down company was removed from our email system, the cleanup accidentally also deleted the email history of any other company whose web address started with the same letters — e.g. removing "simply-learn" also erased "simply-learning-tuition"'s email history. This fixes the cleanup so it only ever removes the exact company being deleted.

## Out of scope

- Recovering the already-deleted history (Simply Learning Tuition and likely others). The messages are gone from the live DB; an RDS point-in-time restore to a side instance would be needed to recover and re-insert them — flagged separately.
- The `deleting company=None` log always prints `None` because TC2 doesn't send `company_name` — not touched here.

Fixes tutorcruncher/TutorCruncher2#17579