### PR TITLE
Add load_recovered.py for restoring deleted email history

### DIFF
--- a/scripts/load_recovered.py
+++ b/scripts/load_recovered.py
@@ -20,6 +20,7 @@ What it does, one agency at a time:
      rows that already exist for the same group uuid + address + send_ts. Every row is stamped
      extra.recovered_batch = <batch-id> (plus recovered_from, trigger, sources) so a batch can be removed
      again with --rollback. The BEFORE INSERT trigger fills the search vector as for normal sends.
+     No schema changes are made: the script only inserts into companies, message_groups and messages.
   4. --dry-run does everything inside a transaction and rolls back, reporting the counts it would insert.
 
 Run with the production URL only after a manual snapshot, off-peak, smallest agency first, and with the
@@ -76,23 +77,53 @@ def group_uuid_for(r: dict) -> str:
 
 
 def rollback_batch(cur, batch_id: str, dry_run: bool) -> None:
+    """Remove a batch: its messages, and any group that exists only because of it.
+
+    A group belongs to the batch if every message in it carries this batch id — which is true of the groups
+    the load created, and false for a group that already held real sends (so those are always left alone).
+    This is worked out before the messages are deleted, while the evidence still exists.
+    """
+    cur.execute(
+        """select distinct m.group_id from messages m
+           where m.extra->>'recovered_batch' = %(b)s
+             and not exists (select 1 from messages o
+                             where o.group_id = m.group_id
+                               and (o.extra->>'recovered_batch') is distinct from %(b)s)""",
+        {'b': batch_id},
+    )
+    group_ids = [r[0] for r in cur.fetchall()]
     cur.execute("select count(*) from messages where extra->>'recovered_batch' = %s", (batch_id,))
     n_msg = cur.fetchone()[0]
-    log(f'batch {batch_id}: {n_msg} messages to delete')
+    log(f'batch {batch_id}: {n_msg} messages and {len(group_ids)} groups to delete')
     if dry_run:
         return
     cur.execute("delete from messages where extra->>'recovered_batch' = %s", (batch_id,))
-    # Groups created by this batch are recorded in recovered_batch_groups; drop those left empty.
-    cur.execute("select to_regclass('recovered_batch_groups')")
-    if cur.fetchone()[0]:
+    n_grp = 0
+    if group_ids:
         cur.execute(
-            """delete from message_groups where id in (
-                 select group_id from recovered_batch_groups where batch_id = %s)
+            """delete from message_groups where id = any(%s)
                and not exists (select 1 from messages m where m.group_id = message_groups.id)""",
-            (batch_id,),
+            (group_ids,),
         )
-        cur.execute('delete from recovered_batch_groups where batch_id = %s', (batch_id,))
-    log(f'batch {batch_id}: deleted {n_msg} messages and their now-empty groups')
+        n_grp = cur.rowcount
+    drop_legacy_group_table(cur, batch_id)
+    log(f'batch {batch_id}: deleted {n_msg} messages and {n_grp} now-empty groups')
+
+
+def drop_legacy_group_table(cur, batch_id: str) -> None:
+    """Earlier versions recorded created groups in a recovered_batch_groups table.
+
+    Nothing writes it any more. Clear this batch's rows and drop the table once it is empty, so a database
+    that was loaded with an older copy of this script does not keep an unused table for ever.
+    """
+    cur.execute("select to_regclass('recovered_batch_groups')")
+    if not cur.fetchone()[0]:
+        return
+    cur.execute('delete from recovered_batch_groups where batch_id = %s', (batch_id,))
+    cur.execute('select count(*) from recovered_batch_groups')
+    if cur.fetchone()[0] == 0:
+        cur.execute('drop table recovered_batch_groups')
+        log('dropped the now-empty legacy recovered_batch_groups table')
 
 
 def main() -> int:
@@ -170,16 +201,13 @@ def load(conn, cur, args) -> int:
     cur.execute('select uuid::text, id from message_groups where uuid = any(%s::uuid[])', (list(groups),))
     group_id = dict(cur.fetchall())
     existing_groups = len(group_id)
-    cur.execute('create table if not exists recovered_batch_groups (batch_id text not null, group_id int not null)')
     new_groups = [(u, g) for u, g in groups.items() if u not in group_id]
     for u, g in new_groups:
         cur.execute(
             'insert into message_groups (uuid, company_id, message_method, created_ts, from_email) values (%s, %s, %s, %s, %s) returning id',
             (u, company_id[g['code']], args.method, g['ts'], g['from_email']),
         )
-        gid = cur.fetchone()[0]
-        group_id[u] = gid
-        cur.execute('insert into recovered_batch_groups (batch_id, group_id) values (%s, %s)', (args.batch_id, gid))
+        group_id[u] = cur.fetchone()[0]
     log(
         f'groups: {len(groups)} in files, {existing_groups} already present, {len(new_groups)} created ({sum(g["synth"] for _, g in new_groups)} synthesised)'
     )

--- a/scripts/load_recovered.py
+++ b/scripts/load_recovered.py
@@ -54,7 +54,24 @@ def log(msg: str) -> None:
     print(f'[{dt.datetime.now():%H:%M:%S}] {msg}', flush=True)
 
 
-def read_rows(input_dir: Path, agency: str, start: dt.date | None, end: dt.date | None, as_code=None):
+def read_rows(
+    input_dir: Path,
+    agency: str,
+    start: dt.date | None,
+    end: dt.date | None,
+    as_code=None,
+    start_ts: str | None = None,
+    end_ts: str | None = None,
+):
+    """Rows for one agency, optionally bounded by day (--start/--end) and by time (--start-ts/--end-ts).
+
+    The timestamp bounds exist for the Route A tail. A subaccount restored from a nightly snapshot
+    was deleted some hours after that snapshot was taken, so Route B supplies only the sends in
+    between. A whole-day filter would also pick up what it sent *after* the deletion, and those rows
+    already exist in the database as real messages — the insert guard would not catch them, because
+    Route B's send_ts comes from a log line and never matches the database's to the microsecond.
+    Both bounds are inclusive and compare as ISO strings, which is what the rendered files hold.
+    """
     files = sorted(input_dir.glob('????-??-??.csv.gz'))
     for f in files:
         day = dt.date.fromisoformat(f.stem[:10])
@@ -62,6 +79,10 @@ def read_rows(input_dir: Path, agency: str, start: dt.date | None, end: dt.date 
             continue
         with gzip.open(f, 'rt', newline='', encoding='utf-8') as fh:
             for r in csv.DictReader(fh):
+                if start_ts and r['send_ts'] < start_ts:
+                    continue
+                if end_ts and r['send_ts'] > end_ts:
+                    continue
                 if r['company_code'] == agency:
                     if as_code:
                         new_code, new_branch = as_code
@@ -180,6 +201,11 @@ def main() -> int:
     ap.add_argument('--batch-id', help='label stamped on every inserted row (extra.recovered_batch)')
     ap.add_argument('--start', type=dt.date.fromisoformat)
     ap.add_argument('--end', type=dt.date.fromisoformat)
+    ap.add_argument('--start-ts', metavar='ISO_TS',
+                    help='only rows with send_ts >= this (inclusive), e.g. 2026-08-26T01:06:00. '
+                         'For the Route A tail, where a whole-day cut would re-insert sends that '
+                         'already exist in the database.')
+    ap.add_argument('--end-ts', metavar='ISO_TS', help='only rows with send_ts <= this (inclusive)')
     ap.add_argument('--batch-size', type=positive_int, default=5000)
     ap.add_argument('--method', default=METHOD,
                     help=f'message method to store (default {METHOD}). Use email-test to view a batch in a local '
@@ -214,7 +240,7 @@ def load(conn, cur, args) -> int:
         if not c or not b:
             sys.exit('--as-code must look like CODE:BRANCH, e.g. testagency:3')
         as_code = (c, b)
-    rows = list(read_rows(args.input, args.agency, args.start, args.end, as_code))
+    rows = list(read_rows(args.input, args.agency, args.start, args.end, as_code, args.start_ts, args.end_ts))
     if not rows:
         log(f'no rows for {args.agency} in {args.input}')
         return 0

--- a/scripts/load_recovered.py
+++ b/scripts/load_recovered.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+Load recovered email records (rendered by the recovery pipeline) into a Morpheus database.
+
+    uv run python scripts/load_recovered.py --dsn "$DATABASE_URL" --input "/path/to/rendered" \
+        --agency <agency-code> --batch-id <agency-code>-2026-09-08 --dry-run
+    uv run python scripts/load_recovered.py --dsn … --input … --agency … --batch-id … [--start 2025-09-01 --end 2026-08-27]
+    uv run python scripts/load_recovered.py --dsn … --rollback <batch-id>
+
+Input: rendered/<date>.csv.gz files (one row per email: send_ts, company_code, branch_id, group_uuid,
+to_address, first_name, last_name, user_id, role_type, trigger, tags, subject, body, from_address,
+reply_to, sources, context_keys).
+
+What it does, one agency at a time:
+  1. companies: ensures a row per "<agency>:<branch>" code (the codes TC2 sends with).
+  2. message_groups: one per group uuid (rows without a uuid get a deterministic uuid5 per code+minute),
+     created_ts = earliest send in the group, message_method 'email-mandrill', from_email from the style.
+     Groups whose uuid already exists are reused, never modified.
+  3. messages: COPY into a TEMP staging table, then INSERT … SELECT in batches of --batch-size, skipping
+     rows that already exist for the same group uuid + address + send_ts. Every row is stamped
+     extra.recovered_batch = <batch-id> (plus recovered_from, trigger, sources) so a batch can be removed
+     again with --rollback. The BEFORE INSERT trigger fills the search vector as for normal sends.
+  4. --dry-run does everything inside a transaction and rolls back, reporting the counts it would insert.
+
+Run with the production URL only after a manual snapshot, off-peak, smallest agency first, and with the
+delete_old_emails beat task paused (recovered groups carry their original dates).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import gzip
+import io
+import json
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import psycopg2
+import psycopg2.extras
+
+csv.field_size_limit(1 << 30)
+METHOD = 'email-mandrill'
+
+
+def log(msg: str) -> None:
+    print(f'[{dt.datetime.now():%H:%M:%S}] {msg}', flush=True)
+
+
+def read_rows(input_dir: Path, agency: str, start: dt.date | None, end: dt.date | None, as_code=None):
+    files = sorted(input_dir.glob('????-??-??.csv.gz'))
+    for f in files:
+        day = dt.date.fromisoformat(f.stem[:10])
+        if (start and day < start) or (end and day > end):
+            continue
+        with gzip.open(f, 'rt', newline='', encoding='utf-8') as fh:
+            for r in csv.DictReader(fh):
+                if r['company_code'] == agency:
+                    if as_code:
+                        new_code, new_branch = as_code
+                        old_tag = f'{r["company_code"]}-{r["branch_id"]}'
+                        new_tag = f'{new_code}-{new_branch}'
+                        r['tags'] = r['tags'].replace(old_tag, new_tag)
+                        r['company_code'], r['branch_id'] = new_code, new_branch
+                    yield r
+
+
+def group_uuid_for(r: dict) -> str:
+    if r['group_uuid']:
+        return r['group_uuid']
+    minute = r['send_ts'][:16]
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f'recovered:{r["company_code"]}:{r["branch_id"]}:{minute}'))
+
+
+def rollback_batch(cur, batch_id: str, dry_run: bool) -> None:
+    cur.execute("select count(*) from messages where extra->>'recovered_batch' = %s", (batch_id,))
+    n_msg = cur.fetchone()[0]
+    log(f'batch {batch_id}: {n_msg} messages to delete')
+    if dry_run:
+        return
+    cur.execute("delete from messages where extra->>'recovered_batch' = %s", (batch_id,))
+    # Groups created by this batch are recorded in recovered_batch_groups; drop those left empty.
+    cur.execute("select to_regclass('recovered_batch_groups')")
+    if cur.fetchone()[0]:
+        cur.execute(
+            """delete from message_groups where id in (
+                 select group_id from recovered_batch_groups where batch_id = %s)
+               and not exists (select 1 from messages m where m.group_id = message_groups.id)""",
+            (batch_id,),
+        )
+        cur.execute('delete from recovered_batch_groups where batch_id = %s', (batch_id,))
+    log(f'batch {batch_id}: deleted {n_msg} messages and their now-empty groups')
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--dsn', required=True)
+    ap.add_argument('--input', type=Path, help='folder of rendered/<date>.csv.gz files')
+    ap.add_argument('--agency', help='agency code exactly as it appears in the rendered files')
+    ap.add_argument('--batch-id', help='label stamped on every inserted row (extra.recovered_batch)')
+    ap.add_argument('--start', type=dt.date.fromisoformat)
+    ap.add_argument('--end', type=dt.date.fromisoformat)
+    ap.add_argument('--batch-size', type=int, default=5000)
+    ap.add_argument('--method', default=METHOD,
+                    help=f'message method to store (default {METHOD}). Use email-test to view a batch in a local '
+                         'dev TC2, whose test email backend queries Morpheus for email-test — never for production.')
+    ap.add_argument('--as-code', metavar='CODE:BRANCH',
+                    help='load under this company code instead of the one in the files, e.g. testagency:3 '
+                         '(local testing only — it re-homes the emails onto another agency/branch)')
+    ap.add_argument('--dry-run', action='store_true')
+    ap.add_argument('--rollback', metavar='BATCH_ID', help='delete everything stamped with this batch id and exit')
+    args = ap.parse_args()
+
+    conn = psycopg2.connect(args.dsn)
+    conn.autocommit = False
+    cur = conn.cursor()
+    try:
+        if args.rollback:
+            rollback_batch(cur, args.rollback, args.dry_run)
+            conn.rollback() if args.dry_run else conn.commit()
+            return 0
+        if not (args.input and args.agency and args.batch_id):
+            sys.exit('--input, --agency and --batch-id are required to load')
+        return load(conn, cur, args)
+    finally:
+        conn.close()
+
+
+def load(conn, cur, args) -> int:
+    t0 = time.monotonic()
+    as_code = None
+    if args.as_code:
+        c, _, b = args.as_code.partition(':')
+        if not c or not b:
+            sys.exit('--as-code must look like CODE:BRANCH, e.g. testagency:3')
+        as_code = (c, b)
+    rows = list(read_rows(args.input, args.agency, args.start, args.end, as_code))
+    if not rows:
+        log(f'no rows for {args.agency} in {args.input}')
+        return 0
+    rows.sort(key=lambda r: r['send_ts'])
+    log(f'{args.agency}: {len(rows)} rows from {rows[0]["send_ts"][:10]} to {rows[-1]["send_ts"][:10]}')
+
+    # 1. companies
+    codes = sorted({f'{r["company_code"]}:{r["branch_id"]}' for r in rows})
+    company_id = {}
+    for code in codes:
+        cur.execute('insert into companies (code) values (%s) on conflict (code) do nothing', (code,))
+        cur.execute('select id from companies where code = %s', (code,))
+        company_id[code] = cur.fetchone()[0]
+    log(f'companies: {company_id}')
+
+    # 2. groups
+    groups: dict[str, dict] = {}
+    for r in rows:
+        u = group_uuid_for(r)
+        g = groups.setdefault(
+            u,
+            dict(
+                code=f'{r["company_code"]}:{r["branch_id"]}',
+                ts=r['send_ts'],
+                from_email=r['from_address'] or None,
+                synth=not r['group_uuid'],
+            ),
+        )
+        g['ts'] = min(g['ts'], r['send_ts'])
+    cur.execute('select uuid::text, id from message_groups where uuid = any(%s::uuid[])', (list(groups),))
+    group_id = dict(cur.fetchall())
+    existing_groups = len(group_id)
+    cur.execute('create table if not exists recovered_batch_groups (batch_id text not null, group_id int not null)')
+    new_groups = [(u, g) for u, g in groups.items() if u not in group_id]
+    for u, g in new_groups:
+        cur.execute(
+            'insert into message_groups (uuid, company_id, message_method, created_ts, from_email) values (%s, %s, %s, %s, %s) returning id',
+            (u, company_id[g['code']], args.method, g['ts'], g['from_email']),
+        )
+        gid = cur.fetchone()[0]
+        group_id[u] = gid
+        cur.execute('insert into recovered_batch_groups (batch_id, group_id) values (%s, %s)', (args.batch_id, gid))
+    log(
+        f'groups: {len(groups)} in files, {existing_groups} already present, {len(new_groups)} created ({sum(g["synth"] for _, g in new_groups)} synthesised)'
+    )
+
+    # 3. messages via staging
+    cur.execute(
+        """create temp table staging_messages (
+             group_uuid text, group_id int, company_id int, send_ts timestamptz, to_first_name text, to_last_name text,
+             to_address text, tags text[], subject text, body text, extra jsonb) on commit drop"""
+    )
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    for r in rows:
+        u = group_uuid_for(r)
+        code = f'{r["company_code"]}:{r["branch_id"]}'
+        tags = json.loads(r['tags'] or '[]')
+        tags = [u] + [t for t in tags if t != u]
+        extra = dict(
+            recovered_batch=args.batch_id,
+            recovered_from='papertrail+bigquery',
+            trigger=r['trigger'] or None,
+            user_id=int(r['user_id']) if r['user_id'] else None,
+            role_type=r['role_type'] or None,
+            sources=json.loads(r['sources'] or '{}'),
+            context_keys=json.loads(r['context_keys'] or '[]'),
+            group_synthesised=not r['group_uuid'],
+            reply_to=r['reply_to'] or None,
+        )
+        w.writerow(
+            [
+                u,
+                group_id[u],
+                company_id[code],
+                r['send_ts'] + ('' if '+' in r['send_ts'] or r['send_ts'].endswith('Z') else '+00:00'),
+                r['first_name'] or '',
+                r['last_name'] or '',
+                r['to_address'] or '',
+                '{' + ','.join('"' + t.replace('\\', '\\\\').replace('"', '\\"') + '"' for t in tags) + '}',
+                r['subject'],
+                r['body'],
+                json.dumps(extra),
+            ]
+        )
+    buf.seek(0)
+    cur.copy_expert('copy staging_messages from stdin with (format csv)', buf)
+    cur.execute(
+        "update staging_messages set to_first_name = nullif(to_first_name, ''), to_last_name = nullif(to_last_name, ''), to_address = nullif(to_address, '')"
+    )
+    cur.execute(
+        """select count(*) from staging_messages s where exists (
+             select 1 from messages m where m.group_id = s.group_id and m.to_address is not distinct from s.to_address and m.send_ts = s.send_ts)"""
+    )
+    dupes = cur.fetchone()[0]
+    log(f'staged {len(rows)} rows; {dupes} already exist (same group, address and send time) and will be skipped')
+
+    inserted = 0
+    while True:
+        cur.execute(
+            """with batch as (
+                 delete from staging_messages s where ctid in (select ctid from staging_messages limit %s) returning *
+               )
+               insert into messages (group_id, company_id, method, send_ts, update_ts, status, to_first_name, to_last_name, to_address, tags, subject, body, extra)
+               select b.group_id, b.company_id, %s, b.send_ts, b.send_ts, 'send', b.to_first_name, b.to_last_name, b.to_address, b.tags, b.subject, b.body, b.extra
+               from batch b
+               where not exists (select 1 from messages m where m.group_id = b.group_id and m.to_address is not distinct from b.to_address and m.send_ts = b.send_ts)""",
+            (args.batch_size, args.method),
+        )
+        n = cur.rowcount
+        cur.execute('select count(*) from staging_messages')
+        left = cur.fetchone()[0]
+        inserted += n
+        log(f'  inserted {n} ({inserted} so far, {left} staged rows left)')
+        if left == 0:
+            break
+
+    if args.dry_run:
+        conn.rollback()
+        log(
+            f'DRY RUN: would insert {inserted} messages, {len(new_groups)} groups, {len([c for c in codes])} company codes for {args.agency}; rolled back'
+        )
+    else:
+        conn.commit()
+        log(
+            f'COMMITTED batch {args.batch_id}: {inserted} messages, {len(new_groups)} groups for {args.agency} in {time.monotonic() - t0:.0f}s'
+        )
+        log(
+            'note: the message_aggregation view refreshes hourly; refresh manually if the dashboard should update sooner'
+        )
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/load_recovered.py
+++ b/scripts/load_recovered.py
@@ -12,10 +12,13 @@ to_address, first_name, last_name, user_id, role_type, trigger, tags, subject, b
 reply_to, sources, context_keys).
 
 What it does, one agency at a time:
+  0. input: rows identical on group uuid + address + send_ts are collapsed to one before anything is
+     written (the rendered files carry ~10% such duplicates from merging papertrail with bigquery).
   1. companies: ensures a row per "<agency>:<branch>" code (the codes TC2 sends with).
   2. message_groups: one per group uuid (rows without a uuid get a deterministic uuid5 per code+minute),
      created_ts = earliest send in the group, message_method 'email-mandrill', from_email from the style.
-     Groups whose uuid already exists are reused, never modified.
+     Groups whose uuid already exists are reused, never modified — and the load refuses to start if such
+     a group belongs to a different company than its rows do.
   3. messages: COPY into a TEMP staging table, then INSERT … SELECT in batches of --batch-size, skipping
      rows that already exist for the same group uuid + address + send_ts. Every row is stamped
      extra.recovered_batch = <batch-id> (plus recovered_from, trigger, sources) so a batch can be removed
@@ -76,6 +79,49 @@ def group_uuid_for(r: dict) -> str:
     return str(uuid.uuid5(uuid.NAMESPACE_URL, f'recovered:{r["company_code"]}:{r["branch_id"]}:{minute}'))
 
 
+def dedupe_rows(rows: list[dict]) -> list[dict]:
+    """Collapse rows identical on (group, to_address, send_ts), keeping the first of each.
+
+    The insert guard in load() skips staged rows that already exist in `messages`, but it cannot see
+    rows inserted by its own statement. Duplicates are adjacent once rows are sorted by send_ts, and
+    COPY preserves that order into the staging heap, so a duplicate pair almost always lands in the
+    same --batch-size chunk and both rows would be written. The key matches the guard's exactly —
+    subject is deliberately excluded so the two passes agree on what a duplicate is.
+    """
+    seen: set[tuple[str, str, str]] = set()
+    deduped = []
+    for r in rows:
+        key = (group_uuid_for(r), r['to_address'], r['send_ts'])
+        if key not in seen:
+            seen.add(key)
+            deduped.append(r)
+    return deduped
+
+
+def existing_group_conflicts(
+    groups: dict[str, dict], group_company: dict[str, int], company_id: dict[str, int]
+) -> list[tuple[str, int, int]]:
+    """Group uuids already in the database whose company is not the one the rows belong to.
+
+    An existing group is reused untouched, but messages.company_id comes from the CSV row, so a
+    mismatch would file one agency's mail under another agency's group. Returns (uuid, db, expected).
+    """
+    conflicts = []
+    for u, g in groups.items():
+        db_company = group_company.get(u)
+        if db_company is not None and db_company != company_id[g['code']]:
+            conflicts.append((u, db_company, company_id[g['code']]))
+    return conflicts
+
+
+def positive_int(v: str) -> int:
+    """--batch-size 0 makes `limit 0` drain nothing from staging, so the insert loop never ends."""
+    n = int(v)
+    if n < 1:
+        raise argparse.ArgumentTypeError(f'must be 1 or more, got {n}')
+    return n
+
+
 def rollback_batch(cur, batch_id: str, dry_run: bool) -> None:
     """Remove a batch: its messages, and any group that exists only because of it.
 
@@ -134,7 +180,7 @@ def main() -> int:
     ap.add_argument('--batch-id', help='label stamped on every inserted row (extra.recovered_batch)')
     ap.add_argument('--start', type=dt.date.fromisoformat)
     ap.add_argument('--end', type=dt.date.fromisoformat)
-    ap.add_argument('--batch-size', type=int, default=5000)
+    ap.add_argument('--batch-size', type=positive_int, default=5000)
     ap.add_argument('--method', default=METHOD,
                     help=f'message method to store (default {METHOD}). Use email-test to view a batch in a local '
                          'dev TC2, whose test email backend queries Morpheus for email-test — never for production.')
@@ -173,6 +219,10 @@ def load(conn, cur, args) -> int:
         log(f'no rows for {args.agency} in {args.input}')
         return 0
     rows.sort(key=lambda r: r['send_ts'])
+    deduped = dedupe_rows(rows)
+    if len(deduped) != len(rows):
+        log(f'input: dropped {len(rows) - len(deduped)} duplicate rows (same group, address and send time)')
+    rows = deduped
     log(f'{args.agency}: {len(rows)} rows from {rows[0]["send_ts"][:10]} to {rows[-1]["send_ts"][:10]}')
 
     # 1. companies
@@ -198,9 +248,18 @@ def load(conn, cur, args) -> int:
             ),
         )
         g['ts'] = min(g['ts'], r['send_ts'])
-    cur.execute('select uuid::text, id from message_groups where uuid = any(%s::uuid[])', (list(groups),))
-    group_id = dict(cur.fetchall())
+    cur.execute('select uuid::text, id, company_id from message_groups where uuid = any(%s::uuid[])', (list(groups),))
+    existing = cur.fetchall()
+    group_id = {u: gid for u, gid, _ in existing}
     existing_groups = len(group_id)
+    conflicts = existing_group_conflicts(groups, {u: cid for u, _, cid in existing}, company_id)
+    if conflicts:
+        for u, db_company, expected in conflicts[:10]:
+            log(f'  group {u} belongs to company {db_company}, but its rows are company {expected}')
+        sys.exit(
+            f'{len(conflicts)} existing group(s) belong to a different company than the rows claim — refusing to '
+            'load. Check --agency and --as-code against the target database.'
+        )
     new_groups = [(u, g) for u, g in groups.items() if u not in group_id]
     for u, g in new_groups:
         cur.execute(

--- a/scripts/load_recovered.py
+++ b/scripts/load_recovered.py
@@ -12,15 +12,21 @@ to_address, first_name, last_name, user_id, role_type, trigger, tags, subject, b
 reply_to, sources, context_keys).
 
 What it does, one agency at a time:
-  0. input: rows identical on group uuid + address + send_ts are collapsed to one before anything is
-     written (the rendered files carry ~10% such duplicates from merging papertrail with bigquery).
+  0. input: rows for the same group uuid + address sent within --dedupe-window seconds (default 5)
+     are collapsed to one before anything is written. Merging papertrail with bigquery left ~10%
+     exact duplicates and a further 6,930 pairs a few milliseconds apart, which an exact key missed.
   1. companies: ensures a row per "<agency>:<branch>" code (the codes TC2 sends with).
   2. message_groups: one per group uuid (rows without a uuid get a deterministic uuid5 per code+minute),
      created_ts = earliest send in the group, message_method 'email-mandrill', from_email from the style.
-     Groups whose uuid already exists are reused, never modified — and the load refuses to start if such
-     a group belongs to a different company than its rows do.
+     Groups whose uuid already exists are reused, never modified. 54 uuids are carried by two different
+     agencies, so ownership is settled first — from the whole input, then overlaid with what the database
+     already holds, which wins — and a row whose uuid belongs to someone else takes the uuid5 path and
+     gets its own group. Without that, those rows block 8 of the 25 agency loads outright.
   3. messages: COPY into a TEMP staging table, then INSERT … SELECT in batches of --batch-size, skipping
-     rows that already exist for the same group uuid + address + send_ts. Every row is stamped
+     rows the database already holds for the same group uuid + address within --dedupe-window seconds.
+     The window matters: every agency kept sending after its own subaccount was deleted, so the rendered
+     files carry post-deletion sends that are still live in production, and their send_ts comes from a
+     log line rather than the app — an exact match never fires and re-inserts them. Every row is stamped
      extra.recovered_batch = <batch-id> (plus recovered_from, trigger, sources) so a batch can be removed
      again with --rollback. The BEFORE INSERT trigger fills the search vector as for normal sends.
      No schema changes are made: the script only inserts into companies, message_groups and messages.
@@ -33,6 +39,7 @@ delete_old_emails beat task paused (recovered groups carry their original dates)
 from __future__ import annotations
 
 import argparse
+import collections
 import csv
 import datetime as dt
 import gzip
@@ -48,6 +55,9 @@ import psycopg2.extras
 
 csv.field_size_limit(1 << 30)
 METHOD = 'email-mandrill'
+# How far apart two sends to the same address in the same group can be and still be the same email.
+# Sized from the rendered data: 6,930 near-duplicate pairs, p99 2s, 6,902 of them under 5s.
+DEDUPE_WINDOW = 5.0
 
 
 def log(msg: str) -> None:
@@ -93,29 +103,88 @@ def read_rows(
                     yield r
 
 
-def group_uuid_for(r: dict) -> str:
-    if r['group_uuid']:
+def majority_owner(input_dir: Path) -> dict[str, str]:
+    """Group uuids used by more than one company code, mapped to the code that holds the most rows.
+
+    54 uuids in the rendered set appear under two agencies. The loader reuses an existing group but
+    refuses when its company is not the one the rows claim, so the minority rows block the whole
+    agency: 8 of 25 loads refuse, 240,759 messages, over 33 rows. Resolving it as the loads run --
+    first one to reach a uuid keeps it -- is order-dependent and would re-home 1,315 of one agency's
+    rows into another's group, so ownership is decided here, once, from the entire input.
+
+    The scan deliberately ignores --start/--end and --start-ts/--end-ts: the answer must not change
+    between the main load and the Route A tail run. Ties break on the code to stay deterministic.
+    """
+    counts: dict[str, collections.Counter] = collections.defaultdict(collections.Counter)
+    for f in sorted(input_dir.glob('????-??-??.csv.gz')):
+        with gzip.open(f, 'rt', newline='', encoding='utf-8') as fh:
+            for r in csv.DictReader(fh):
+                if r['group_uuid']:
+                    counts[r['group_uuid']][f'{r["company_code"]}:{r["branch_id"]}'] += 1
+    return {u: min(c.items(), key=lambda kv: (-kv[1], kv[0]))[0] for u, c in counts.items() if len(c) > 1}
+
+
+def merge_db_owners(rendered: dict[str, str], db: dict[str, str]) -> dict[str, str]:
+    """Ownership from the rendered files, overlaid with what the database already holds.
+
+    The database wins. Its groups are real rows -- Route A's restored history, or live sends -- so a
+    rendered row carrying one of their uuids is the one that has borrowed it, whatever the rendered
+    majority says. The snapshot restore brings in 57,705 real groups, one of which a reconstructed
+    agency also carries.
+    """
+    return {**rendered, **db}
+
+
+def group_uuid_for(r: dict, owners: dict[str, str] | None = None) -> str:
+    """The group a row belongs in: its own uuid, unless that uuid belongs to another agency.
+
+    A row whose uuid is owned by a different company code falls through to the synthesised path, the
+    same one rows with no uuid take, giving that agency its own group instead of borrowing one.
+    """
+    code = f'{r["company_code"]}:{r["branch_id"]}'
+    if r['group_uuid'] and (owners is None or owners.get(r['group_uuid'], code) == code):
         return r['group_uuid']
     minute = r['send_ts'][:16]
     return str(uuid.uuid5(uuid.NAMESPACE_URL, f'recovered:{r["company_code"]}:{r["branch_id"]}:{minute}'))
 
 
-def dedupe_rows(rows: list[dict]) -> list[dict]:
-    """Collapse rows identical on (group, to_address, send_ts), keeping the first of each.
+def parse_ts(s: str) -> dt.datetime:
+    """One rendered send_ts as an aware UTC datetime. A value without an offset is UTC, which is the
+    same assumption the COPY step makes when it appends +00:00."""
+    ts = dt.datetime.fromisoformat(s)
+    return ts.replace(tzinfo=dt.timezone.utc) if ts.tzinfo is None else ts.astimezone(dt.timezone.utc)
+
+
+def dedupe_rows(
+    rows: list[dict], window_seconds: float = DEDUPE_WINDOW, owners: dict[str, str] | None = None
+) -> list[dict]:
+    """Collapse rows for the same (group, to_address) sent within window_seconds, keeping the first.
 
     The insert guard in load() skips staged rows that already exist in `messages`, but it cannot see
     rows inserted by its own statement. Duplicates are adjacent once rows are sorted by send_ts, and
     COPY preserves that order into the staging heap, so a duplicate pair almost always lands in the
-    same --batch-size chunk and both rows would be written. The key matches the guard's exactly —
-    subject is deliberately excluded so the two passes agree on what a duplicate is.
+    same --batch-size chunk and both rows would be written. Subject is deliberately excluded from the
+    key so this pass and the SQL guard agree on what a duplicate is.
+
+    The window is not cosmetic. The rendered files were merged from two sources whose clocks differ,
+    so the same email appears twice a few milliseconds apart about as often as it appears twice
+    identically — 6,930 such pairs against 38,383 exact ones, median 43ms, p99 2s. An exact key
+    collapses only the second kind and writes the first kind twice.
+
+    Each row is measured against the last row *kept*, not its predecessor, so a long run of sends a
+    few seconds apart cannot chain into a single kept row and swallow genuinely distinct email.
+    window_seconds=0 restores the old exact-match behaviour.
     """
-    seen: set[tuple[str, str, str]] = set()
+    kept_at: dict[tuple[str, str], dt.datetime] = {}
     deduped = []
     for r in rows:
-        key = (group_uuid_for(r), r['to_address'], r['send_ts'])
-        if key not in seen:
-            seen.add(key)
-            deduped.append(r)
+        key = (group_uuid_for(r, owners), r['to_address'])
+        ts = parse_ts(r['send_ts'])
+        previous = kept_at.get(key)
+        if previous is not None and abs((ts - previous).total_seconds()) <= window_seconds:
+            continue
+        kept_at[key] = ts
+        deduped.append(r)
     return deduped
 
 
@@ -141,6 +210,14 @@ def positive_int(v: str) -> int:
     if n < 1:
         raise argparse.ArgumentTypeError(f'must be 1 or more, got {n}')
     return n
+
+
+def non_negative_float(v: str) -> float:
+    """A negative window would make the BETWEEN range empty, silently disabling the guard."""
+    f = float(v)
+    if f < 0:
+        raise argparse.ArgumentTypeError(f'must be 0 or more, got {f}')
+    return f
 
 
 def rollback_batch(cur, batch_id: str, dry_run: bool) -> None:
@@ -201,18 +278,37 @@ def main() -> int:
     ap.add_argument('--batch-id', help='label stamped on every inserted row (extra.recovered_batch)')
     ap.add_argument('--start', type=dt.date.fromisoformat)
     ap.add_argument('--end', type=dt.date.fromisoformat)
-    ap.add_argument('--start-ts', metavar='ISO_TS',
-                    help='only rows with send_ts >= this (inclusive), e.g. 2026-08-26T01:06:00. '
-                         'For the Route A tail, where a whole-day cut would re-insert sends that '
-                         'already exist in the database.')
+    ap.add_argument(
+        '--start-ts',
+        metavar='ISO_TS',
+        help='only rows with send_ts >= this (inclusive), e.g. 2026-08-26T01:06:00. '
+        'For the Route A tail, where a whole-day cut would re-insert sends that '
+        'already exist in the database.',
+    )
     ap.add_argument('--end-ts', metavar='ISO_TS', help='only rows with send_ts <= this (inclusive)')
     ap.add_argument('--batch-size', type=positive_int, default=5000)
-    ap.add_argument('--method', default=METHOD,
-                    help=f'message method to store (default {METHOD}). Use email-test to view a batch in a local '
-                         'dev TC2, whose test email backend queries Morpheus for email-test — never for production.')
-    ap.add_argument('--as-code', metavar='CODE:BRANCH',
-                    help='load under this company code instead of the one in the files, e.g. testagency:3 '
-                         '(local testing only — it re-homes the emails onto another agency/branch)')
+    ap.add_argument(
+        '--dedupe-window',
+        type=non_negative_float,
+        default=DEDUPE_WINDOW,
+        metavar='SECONDS',
+        help=f'treat two sends to the same address in the same group as the same email when they are '
+        f'within this many seconds (default {DEDUPE_WINDOW}). Applies both to the input and to '
+        'the check against what the database already holds. 0 means exact match only, which '
+        're-inserts live email whose timestamp differs by microseconds.',
+    )
+    ap.add_argument(
+        '--method',
+        default=METHOD,
+        help=f'message method to store (default {METHOD}). Use email-test to view a batch in a local '
+        'dev TC2, whose test email backend queries Morpheus for email-test — never for production.',
+    )
+    ap.add_argument(
+        '--as-code',
+        metavar='CODE:BRANCH',
+        help='load under this company code instead of the one in the files, e.g. testagency:3 '
+        '(local testing only — it re-homes the emails onto another agency/branch)',
+    )
     ap.add_argument('--dry-run', action='store_true')
     ap.add_argument('--rollback', metavar='BATCH_ID', help='delete everything stamped with this batch id and exit')
     args = ap.parse_args()
@@ -245,9 +341,27 @@ def load(conn, cur, args) -> int:
         log(f'no rows for {args.agency} in {args.input}')
         return 0
     rows.sort(key=lambda r: r['send_ts'])
-    deduped = dedupe_rows(rows)
+    # Decided from the whole input, before anything is written, so the answer cannot depend on
+    # which agencies have already been loaded.
+    owners = majority_owner(args.input)
+    cur.execute(
+        """select g.uuid::text, c.code from message_groups g join companies c on c.id = g.company_id
+           where g.uuid = any(%s::uuid[])""",
+        (sorted({r['group_uuid'] for r in rows if r['group_uuid']}),),
+    )
+    owners = merge_db_owners(owners, dict(cur.fetchall()))
+    borrowed = sum(
+        1
+        for r in rows
+        if r['group_uuid'] and owners.get(r['group_uuid'], '') not in ('', f'{r["company_code"]}:{r["branch_id"]}')
+    )
+    if borrowed:
+        log(f'groups: {borrowed} row(s) carry a uuid owned by another agency; giving them their own group')
+    deduped = dedupe_rows(rows, args.dedupe_window, owners)
     if len(deduped) != len(rows):
-        log(f'input: dropped {len(rows) - len(deduped)} duplicate rows (same group, address and send time)')
+        log(
+            f'input: dropped {len(rows) - len(deduped)} duplicate rows (same group and address within {args.dedupe_window}s)'
+        )
     rows = deduped
     log(f'{args.agency}: {len(rows)} rows from {rows[0]["send_ts"][:10]} to {rows[-1]["send_ts"][:10]}')
 
@@ -263,7 +377,7 @@ def load(conn, cur, args) -> int:
     # 2. groups
     groups: dict[str, dict] = {}
     for r in rows:
-        u = group_uuid_for(r)
+        u = group_uuid_for(r, owners)
         g = groups.setdefault(
             u,
             dict(
@@ -306,7 +420,7 @@ def load(conn, cur, args) -> int:
     buf = io.StringIO()
     w = csv.writer(buf)
     for r in rows:
-        u = group_uuid_for(r)
+        u = group_uuid_for(r, owners)
         code = f'{r["company_code"]}:{r["branch_id"]}'
         tags = json.loads(r['tags'] or '[]')
         tags = [u] + [t for t in tags if t != u]
@@ -341,24 +455,28 @@ def load(conn, cur, args) -> int:
     cur.execute(
         "update staging_messages set to_first_name = nullif(to_first_name, ''), to_last_name = nullif(to_last_name, ''), to_address = nullif(to_address, '')"
     )
+    window = f'{args.dedupe_window} seconds'
     cur.execute(
         """select count(*) from staging_messages s where exists (
-             select 1 from messages m where m.group_id = s.group_id and m.to_address is not distinct from s.to_address and m.send_ts = s.send_ts)"""
+             select 1 from messages m where m.group_id = s.group_id and m.to_address is not distinct from s.to_address
+               and m.send_ts between s.send_ts - %(w)s::interval and s.send_ts + %(w)s::interval)""",
+        {'w': window},
     )
     dupes = cur.fetchone()[0]
-    log(f'staged {len(rows)} rows; {dupes} already exist (same group, address and send time) and will be skipped')
+    log(f'staged {len(rows)} rows; {dupes} already exist (same group and address within {window}) and will be skipped')
 
     inserted = 0
     while True:
         cur.execute(
             """with batch as (
-                 delete from staging_messages s where ctid in (select ctid from staging_messages limit %s) returning *
+                 delete from staging_messages s where ctid in (select ctid from staging_messages limit %(n)s) returning *
                )
                insert into messages (group_id, company_id, method, send_ts, update_ts, status, to_first_name, to_last_name, to_address, tags, subject, body, extra)
-               select b.group_id, b.company_id, %s, b.send_ts, b.send_ts, 'send', b.to_first_name, b.to_last_name, b.to_address, b.tags, b.subject, b.body, b.extra
+               select b.group_id, b.company_id, %(method)s, b.send_ts, b.send_ts, 'send', b.to_first_name, b.to_last_name, b.to_address, b.tags, b.subject, b.body, b.extra
                from batch b
-               where not exists (select 1 from messages m where m.group_id = b.group_id and m.to_address is not distinct from b.to_address and m.send_ts = b.send_ts)""",
-            (args.batch_size, args.method),
+               where not exists (select 1 from messages m where m.group_id = b.group_id and m.to_address is not distinct from b.to_address
+                                   and m.send_ts between b.send_ts - %(w)s::interval and b.send_ts + %(w)s::interval)""",
+            {'n': args.batch_size, 'method': args.method, 'w': window},
         )
         n = cur.rowcount
         cur.execute('select count(*) from staging_messages')

--- a/scripts/restore_from_snapshot.py
+++ b/scripts/restore_from_snapshot.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""
+Restore deleted email history from an RDS snapshot export.
+
+Route A of the issue #548 recovery, for the subaccounts whose deletion happened after the nightly
+snapshot was taken. Unlike Route B (scripts/load_recovered.py), which loads rows *reconstructed* from
+send logs, this loads the real rows straight out of a snapshot export: real bodies, real delivery
+events, real click links, real provider ids. Nothing is rendered or guessed.
+
+    uv run python scripts/restore_from_snapshot.py --dsn "$DSN" --input /path/to/route_a_filtered --dry-run
+    uv run python scripts/restore_from_snapshot.py --dsn "$DSN" --input /path/to/route_a_filtered
+    uv run python scripts/restore_from_snapshot.py --dsn "$DSN" --input /path/to/route_a_filtered --rollback
+
+Input: route_a_filtered/{message_groups,messages,events,links}/**/*.parquet, produced by the
+recovery folder's route_a_extract.py.
+
+What it does, in dependency order (groups -> messages -> events -> links):
+  1. Original primary keys are preserved. Deleted ids were never reused and the sequences have only
+     moved forward, so message_groups.id, messages.id, events.id and links.id all go back exactly as
+     they were -- which means events.message_id and links.message_id need no translation at all.
+     The load refuses to start if any id is >= its sequence, since that would collide with a future
+     insert (--allow-id-overlap to override, only if you know why).
+  2. company_id is the ONE thing remapped. The delete removed the companies rows and later sends
+     re-created them with new ids, so snapshot company ids are matched to current ones by `code`.
+  3. Columns are the intersection of what the parquet has and what the target table has, minus the
+     ones the database owns. The snapshot carries spam_status/spam_reason, which this codebase's
+     models do not define, so whether they are restored depends on the target -- not on a guess here.
+  4. `vector` is never inserted: the create_tsvector BEFORE INSERT trigger rebuilds it, exactly as it
+     does for a normal send.
+  5. COPY into a temp staging table, then INSERT ... SELECT in --batch-size chunks with
+     ON CONFLICT (id) DO NOTHING, so a re-run is a no-op rather than a duplicate.
+
+Rollback needs no bookkeeping: the ids are in the parquet files, so --rollback deletes exactly those
+ids. Restored rows are therefore byte-identical to the originals, carrying no marker of the restore.
+
+Before running against production: take a manual RDS snapshot, and go off-peak -- every inserted
+event fires the update_message AFTER INSERT trigger, so that step dominates the run time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import io
+import sys
+from pathlib import Path
+
+import psycopg2
+import psycopg2.extras
+import pyarrow.parquet as pq
+
+# Load order matters: each table's foreign keys point at the one before it.
+TABLES = ['message_groups', 'messages', 'events', 'links']
+
+# Columns the database fills in itself and we must never supply.
+#   vector  -- rebuilt by the create_tsvector trigger on insert
+SKIP_COLUMNS = {'vector'}
+
+# Postgres array columns arrive from the parquet export as array literals ('{a,b,c}'), so the
+# staging table holds them as text and the insert casts them back.
+ARRAY_COLUMNS = {'tags', 'attachments'}
+JSON_COLUMNS = {'extra'}
+
+
+def log(msg: str) -> None:
+    print(f'[{dt.datetime.now():%H:%M:%S}] {msg}', flush=True)
+
+
+def parquet_files(input_dir: Path, table: str) -> list[Path]:
+    return sorted((input_dir / table).rglob('*.parquet'))
+
+
+def read_table(input_dir: Path, table: str, columns: list[str] | None = None):
+    files = parquet_files(input_dir, table)
+    if not files:
+        sys.exit(f'no parquet files under {input_dir / table}')
+    import pyarrow as pa
+
+    return pa.concat_tables([pq.read_table(f, columns=columns) for f in files])
+
+
+def target_columns(cur, table: str) -> list[str]:
+    cur.execute(
+        'select column_name from information_schema.columns where table_schema=%s and table_name=%s',
+        ('public', table),
+    )
+    return [r[0] for r in cur.fetchall()]
+
+
+def company_remap(cur, input_dir: Path) -> dict[int, int]:
+    """snapshot companies.id -> current companies.id, matched on code.
+
+    The subaccount delete removed the companies rows outright; later sends re-created them under the
+    same codes with fresh ids. Codes are unique and stable, so they are the join key -- ids are not.
+    """
+    snap = read_table(input_dir.parent / 'route_a', 'companies') if (input_dir.parent / 'route_a').exists() else None
+    if snap is None:
+        sys.exit(f'need the snapshot companies table at {input_dir.parent / "route_a" / "companies"}')
+    snap_by_id = dict(zip(snap['id'].to_pylist(), snap['code'].to_pylist()))
+
+    groups = read_table(input_dir, 'message_groups', ['company_id'])
+    used = sorted(set(groups['company_id'].to_pylist()))
+
+    cur.execute('select code, id from companies')
+    current = dict(cur.fetchall())
+
+    mapping, missing = {}, []
+    for old_id in used:
+        code = snap_by_id.get(old_id)
+        if code is None:
+            missing.append(f'snapshot company id {old_id} has no row in the snapshot companies table')
+        elif code not in current:
+            missing.append(f'{code!r} (snapshot id {old_id}) does not exist in the target database')
+        else:
+            mapping[old_id] = current[code]
+    if missing:
+        sys.exit(
+            'cannot map every company:\n  ' + '\n  '.join(missing) + '\n\n'
+            'Every code the restored rows belong to must already exist in the target. If one is '
+            'missing, the agency has not sent anything since the wipe -- create the companies row '
+            'first (a plain insert of the code) and re-run.'
+        )
+    return mapping
+
+
+def check_sequences(cur, input_dir: Path, allow_overlap: bool) -> None:
+    """Every restored id must sit below its sequence, or a future insert collides with it."""
+    problems = []
+    for table in TABLES:
+        ids = read_table(input_dir, table, ['id'])['id']
+        max_id = max(ids.to_pylist())
+        cur.execute('select last_value from %s' % f'{table}_id_seq')
+        seq = cur.fetchone()[0]
+        log(f'  {table:<15} max restored id {max_id:>12,}   sequence at {seq:>12,}')
+        if max_id >= seq:
+            problems.append(f'{table}: max id {max_id:,} >= sequence {seq:,}')
+    if problems and not allow_overlap:
+        sys.exit(
+            'restored ids reach past the sequence:\n  ' + '\n  '.join(problems) + '\n\n'
+            'Inserting them would collide with rows the database is about to create. '
+            'Pass --allow-id-overlap only if you have bumped the sequences yourself.'
+        )
+
+
+def load_one(cur, input_dir: Path, table: str, remap: dict[int, int], batch_size: int) -> tuple[int, int]:
+    """COPY one table into staging, then insert the rows that are not already there."""
+    available = set(target_columns(cur, table))
+    data = read_table(input_dir, table)
+    cols = [c for c in data.column_names if c in available and c not in SKIP_COLUMNS]
+    dropped = [c for c in data.column_names if c not in cols]
+    if dropped:
+        log(f'  {table}: not inserting {", ".join(sorted(dropped))}')
+
+    staging = f'_restore_{table}'
+    cur.execute(f'create temp table {staging} (like {table} including defaults excluding constraints) on commit drop')
+    # The array/json columns are text in the parquet; widen them in staging and cast on insert.
+    for col in cols:
+        if col in ARRAY_COLUMNS | JSON_COLUMNS:
+            cur.execute(f'alter table {staging} alter column {col} type text using {col}::text')
+    cur.execute(f'alter table {staging} drop column if exists vector')
+
+    buf = io.StringIO()
+    rows = data.select(cols).to_pylist()
+    remapped = 0
+    for row in rows:
+        if 'company_id' in row and row['company_id'] in remap:
+            row['company_id'] = remap[row['company_id']]
+            remapped += 1
+        buf.write('\t'.join(pg_text(row[c]) for c in cols) + '\n')
+    buf.seek(0)
+    cur.copy_expert(f'copy {staging} ({", ".join(cols)}) from stdin', buf)
+    log(f'  {table}: staged {len(rows):,} rows' + (f', {remapped:,} company ids remapped' if remapped else ''))
+
+    select_cols = ', '.join(
+        f'{c}::varchar[]' if c in ARRAY_COLUMNS else f'{c}::jsonb' if c in JSON_COLUMNS else c for c in cols
+    )
+    inserted = 0
+    while True:
+        cur.execute(
+            f"""with batch as (delete from {staging} where id in
+                    (select id from {staging} limit {batch_size}) returning *)
+                insert into {table} ({', '.join(cols)})
+                select {select_cols} from batch
+                on conflict (id) do nothing"""
+        )
+        if not cur.rowcount:
+            cur.execute(f'select count(*) from {staging}')
+            if not cur.fetchone()[0]:
+                break
+            continue
+        inserted += cur.rowcount
+    return len(rows), inserted
+
+
+def pg_text(v) -> str:
+    """One value as a COPY-format text field."""
+    if v is None:
+        return '\\N'
+    if v is True:
+        return 't'
+    if v is False:
+        return 'f'
+    s = str(v)
+    return s.replace('\\', '\\\\').replace('\t', '\\t').replace('\n', '\\n').replace('\r', '\\r')
+
+
+def rollback(cur, input_dir: Path, batch_size: int) -> None:
+    """Delete exactly the restored ids, children first."""
+    for table in reversed(TABLES):
+        ids = read_table(input_dir, table, ['id'])['id'].to_pylist()
+        deleted = 0
+        for i in range(0, len(ids), batch_size):
+            cur.execute(f'delete from {table} where id = any(%s)', (ids[i : i + batch_size],))
+            deleted += cur.rowcount
+        log(f'  {table}: deleted {deleted:,} of {len(ids):,}')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--dsn', required=True)
+    ap.add_argument('--input', type=Path, required=True, help='route_a_filtered folder')
+    ap.add_argument('--batch-size', type=int, default=5000)
+    ap.add_argument('--dry-run', action='store_true', help='do everything, then roll the transaction back')
+    ap.add_argument('--rollback', action='store_true', help='delete the restored ids and exit')
+    ap.add_argument('--allow-id-overlap', action='store_true')
+    args = ap.parse_args()
+
+    conn = psycopg2.connect(args.dsn)
+    conn.autocommit = False
+    cur = conn.cursor()
+
+    if args.rollback:
+        log('rollback: deleting restored ids')
+        rollback(cur, args.input, args.batch_size)
+        conn.commit()
+        log('rollback committed')
+        return
+
+    log('checking sequences')
+    check_sequences(cur, args.input, args.allow_id_overlap)
+
+    remap = company_remap(cur, args.input)
+    log(f'company remap: {", ".join(f"{o}->{n}" for o, n in sorted(remap.items()))}')
+
+    totals = []
+    for table in TABLES:
+        read, inserted = load_one(cur, args.input, table, remap, args.batch_size)
+        totals.append((table, read, inserted))
+        log(f'  {table}: inserted {inserted:,} (skipped {read - inserted:,} already present)')
+
+    log('')
+    for table, read, inserted in totals:
+        log(f'{table:<15} read {read:>9,}   inserted {inserted:>9,}')
+
+    if args.dry_run:
+        conn.rollback()
+        log('\nDRY RUN — transaction rolled back, nothing written')
+    else:
+        conn.commit()
+        log('\ncommitted')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/restore_from_snapshot.py
+++ b/scripts/restore_from_snapshot.py
@@ -47,7 +47,6 @@ from pathlib import Path
 
 import psycopg2
 import psycopg2.extras
-import pyarrow.parquet as pq
 
 # Load order matters: each table's foreign keys point at the one before it.
 TABLES = ['message_groups', 'messages', 'events', 'links']
@@ -71,11 +70,14 @@ def parquet_files(input_dir: Path, table: str) -> list[Path]:
 
 
 def read_table(input_dir: Path, table: str, columns: list[str] | None = None):
+    # pyarrow is imported here rather than at module scope so the pure helpers below can be
+    # imported and tested without it.
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
     files = parquet_files(input_dir, table)
     if not files:
         sys.exit(f'no parquet files under {input_dir / table}')
-    import pyarrow as pa
-
     return pa.concat_tables([pq.read_table(f, columns=columns) for f in files])
 
 
@@ -87,12 +89,39 @@ def target_columns(cur, table: str) -> list[str]:
     return [r[0] for r in cur.fetchall()]
 
 
-def company_remap(cur, input_dir: Path) -> dict[int, int]:
-    """snapshot companies.id -> current companies.id, matched on code.
+def resolve_remap(snap_by_id: dict[int, str], used_ids: list[int], current_by_code: dict[str, int]):
+    """snapshot companies.id -> current companies.id, matched on code. Returns (mapping, problems).
 
     The subaccount delete removed the companies rows outright; later sends re-created them under the
     same codes with fresh ids. Codes are unique and stable, so they are the join key -- ids are not.
+    Getting this wrong files one agency's mail under another, so it is resolved for every id the rows
+    actually use, and any id that cannot be resolved is an error rather than a row left behind.
     """
+    mapping, problems = {}, []
+    for old_id in used_ids:
+        code = snap_by_id.get(old_id)
+        if code is None:
+            problems.append(f'snapshot company id {old_id} has no row in the snapshot companies table')
+        elif code not in current_by_code:
+            problems.append(f'{code!r} (snapshot id {old_id}) does not exist in the target database')
+        else:
+            mapping[old_id] = current_by_code[code]
+    return mapping, problems
+
+
+def sequence_problems(max_ids: dict[str, int], sequences: dict[str, int]) -> list[str]:
+    """Tables whose restored ids reach their sequence, which a future insert would then collide with.
+
+    Restoring original primary keys is only safe while every one of them sits below the sequence:
+    the ids were allocated before the delete and the sequence has only moved forward since, so this
+    should always hold -- and if it does not, something is wrong enough to stop for.
+    """
+    return [
+        f'{t}: max id {max_ids[t]:,} >= sequence {sequences[t]:,}' for t in max_ids if max_ids[t] >= sequences[t]
+    ]
+
+
+def company_remap(cur, input_dir: Path) -> dict[int, int]:
     snap = read_table(input_dir.parent / 'route_a', 'companies') if (input_dir.parent / 'route_a').exists() else None
     if snap is None:
         sys.exit(f'need the snapshot companies table at {input_dir.parent / "route_a" / "companies"}')
@@ -102,20 +131,10 @@ def company_remap(cur, input_dir: Path) -> dict[int, int]:
     used = sorted(set(groups['company_id'].to_pylist()))
 
     cur.execute('select code, id from companies')
-    current = dict(cur.fetchall())
-
-    mapping, missing = {}, []
-    for old_id in used:
-        code = snap_by_id.get(old_id)
-        if code is None:
-            missing.append(f'snapshot company id {old_id} has no row in the snapshot companies table')
-        elif code not in current:
-            missing.append(f'{code!r} (snapshot id {old_id}) does not exist in the target database')
-        else:
-            mapping[old_id] = current[code]
-    if missing:
+    mapping, problems = resolve_remap(snap_by_id, used, dict(cur.fetchall()))
+    if problems:
         sys.exit(
-            'cannot map every company:\n  ' + '\n  '.join(missing) + '\n\n'
+            'cannot map every company:\n  ' + '\n  '.join(problems) + '\n\n'
             'Every code the restored rows belong to must already exist in the target. If one is '
             'missing, the agency has not sent anything since the wipe -- create the companies row '
             'first (a plain insert of the code) and re-run.'
@@ -124,16 +143,14 @@ def company_remap(cur, input_dir: Path) -> dict[int, int]:
 
 
 def check_sequences(cur, input_dir: Path, allow_overlap: bool) -> None:
-    """Every restored id must sit below its sequence, or a future insert collides with it."""
-    problems = []
+    max_ids, sequences = {}, {}
     for table in TABLES:
-        ids = read_table(input_dir, table, ['id'])['id']
-        max_id = max(ids.to_pylist())
+        max_ids[table] = max(read_table(input_dir, table, ['id'])['id'].to_pylist())
         cur.execute('select last_value from %s' % f'{table}_id_seq')
-        seq = cur.fetchone()[0]
-        log(f'  {table:<15} max restored id {max_id:>12,}   sequence at {seq:>12,}')
-        if max_id >= seq:
-            problems.append(f'{table}: max id {max_id:,} >= sequence {seq:,}')
+        sequences[table] = cur.fetchone()[0]
+        log(f'  {table:<15} max restored id {max_ids[table]:>12,}   sequence at {sequences[table]:>12,}')
+
+    problems = sequence_problems(max_ids, sequences)
     if problems and not allow_overlap:
         sys.exit(
             'restored ids reach past the sequence:\n  ' + '\n  '.join(problems) + '\n\n'

--- a/scripts/restore_from_snapshot.py
+++ b/scripts/restore_from_snapshot.py
@@ -154,9 +154,7 @@ def sequence_problems(max_ids: dict[str, int], sequences: dict[str, int]) -> lis
     the ids were allocated before the delete and the sequence has only moved forward since, so this
     should always hold -- and if it does not, something is wrong enough to stop for.
     """
-    return [
-        f'{t}: max id {max_ids[t]:,} >= sequence {sequences[t]:,}' for t in max_ids if max_ids[t] >= sequences[t]
-    ]
+    return [f'{t}: max id {max_ids[t]:,} >= sequence {sequences[t]:,}' for t in max_ids if max_ids[t] >= sequences[t]]
 
 
 def check_target_clean(cur, input_dir: Path) -> None:

--- a/scripts/restore_from_snapshot.py
+++ b/scripts/restore_from_snapshot.py
@@ -32,6 +32,13 @@ What it does, in dependency order (groups -> messages -> events -> links):
 
 Rollback needs no bookkeeping: the ids are in the parquet files, so --rollback deletes exactly those
 ids. Restored rows are therefore byte-identical to the originals, carrying no marker of the restore.
+That equivalence rests on the pre-flight refusing to start when the target already holds any id or
+group uuid we are about to restore, so nothing --rollback deletes can be a row we did not write.
+
+The whole load is one transaction: if anything fails at any point, the database rolls all of it back
+and the target is untouched. --rollback is for undoing a restore that already committed.
+
+Needs pyarrow, which the app does not depend on -- run it with `uv run --with pyarrow python ...`.
 
 Before running against production: take a manual RDS snapshot, and go off-peak -- every inserted
 event fires the update_message AFTER INSERT trigger, so that step dominates the run time.
@@ -109,6 +116,37 @@ def resolve_remap(snap_by_id: dict[int, str], used_ids: list[int], current_by_co
     return mapping, problems
 
 
+def preflight_problems(existing_ids: dict[str, int], uuid_conflicts: list[tuple[str, int, int]]) -> list[str]:
+    """Reasons the target is not in a fit state to restore into. Empty means go.
+
+    Two separate hazards, both fatal before a row is written rather than partway through:
+
+    `existing_ids` -- how many of the ids we are about to restore the target already holds. Should be
+    zero: these ids were allocated before the delete and nothing since can have reused them. If it is
+    not zero, either a previous restore already committed (roll that back first) or something is
+    wrong enough to stop for. Refusing here is also what makes --rollback exact: every id in the
+    parquet was then written by us, so deleting them all cannot touch a row we did not create.
+
+    `uuid_conflicts` -- (uuid, id in target, id we would restore). message_groups.uuid carries its own
+    unique index, which `ON CONFLICT (id)` does not arbitrate, so a group already present under a
+    different id aborts the transaction on a bare duplicate-key error. Reachable whenever Route B has
+    loaded the same agency: 26,758 of these two agencies' group uuids appear in both datasets. The
+    documented order avoids it (Route B only supplies the post-snapshot tail, which shares none), but
+    a clear refusal beats a cryptic abort after staging half a million rows.
+    """
+    problems = []
+    for table, n in sorted(existing_ids.items()):
+        if n:
+            problems.append(f'{table}: {n:,} of the ids to restore already exist in the target')
+    if uuid_conflicts:
+        shown = ', '.join(f'{u} (target id {db}, restoring {mine})' for u, db, mine in uuid_conflicts[:3])
+        problems.append(
+            f'message_groups: {len(uuid_conflicts):,} uuid(s) already exist under a different id — {shown}'
+            + ('…' if len(uuid_conflicts) > 3 else '')
+        )
+    return problems
+
+
 def sequence_problems(max_ids: dict[str, int], sequences: dict[str, int]) -> list[str]:
     """Tables whose restored ids reach their sequence, which a future insert would then collide with.
 
@@ -121,14 +159,43 @@ def sequence_problems(max_ids: dict[str, int], sequences: dict[str, int]) -> lis
     ]
 
 
+def check_target_clean(cur, input_dir: Path) -> None:
+    """Refuse before writing anything if the target already holds ids or uuids we are restoring."""
+    existing = {}
+    for table in TABLES:
+        ids = read_table(input_dir, table, ['id'])['id'].to_pylist()
+        cur.execute(f'select count(*) from {table} where id = any(%s)', (ids,))
+        existing[table] = cur.fetchone()[0]
+
+    groups = read_table(input_dir, 'message_groups', ['id', 'uuid'])
+    mine = dict(zip(groups['uuid'].to_pylist(), groups['id'].to_pylist()))
+    cur.execute('select uuid::text, id from message_groups where uuid::text = any(%s)', (list(mine),))
+    conflicts = [(u, db_id, mine[u]) for u, db_id in cur.fetchall() if db_id != mine[u]]
+
+    problems = preflight_problems(existing, conflicts)
+    if problems:
+        sys.exit(
+            'the target is not clean for this restore:\n  ' + '\n  '.join(problems) + '\n\n'
+            'If a previous restore committed, roll it back first. If Route B loaded these agencies, '
+            'roll that batch back — Route A supersedes it, since these are the real messages rather '
+            'than reconstructions. Nothing has been written.'
+        )
+    log('  target is clean: no restored id or group uuid already present')
+
+
 def company_remap(cur, input_dir: Path) -> dict[int, int]:
     snap = read_table(input_dir.parent / 'route_a', 'companies') if (input_dir.parent / 'route_a').exists() else None
     if snap is None:
         sys.exit(f'need the snapshot companies table at {input_dir.parent / "route_a" / "companies"}')
     snap_by_id = dict(zip(snap['id'].to_pylist(), snap['code'].to_pylist()))
 
-    groups = read_table(input_dir, 'message_groups', ['company_id'])
-    used = sorted(set(groups['company_id'].to_pylist()))
+    # Every table that carries a company_id, not just message_groups: the remap is applied to all of
+    # them, so building it from one would let an id the other uses fall through unmapped.
+    used = set()
+    for table in TABLES:
+        if 'company_id' in read_table(input_dir, table).column_names:
+            used |= set(read_table(input_dir, table, ['company_id'])['company_id'].to_pylist())
+    used = sorted(used)
 
     cur.execute('select code, id from companies')
     mapping, problems = resolve_remap(snap_by_id, used, dict(cur.fetchall()))
@@ -180,7 +247,16 @@ def load_one(cur, input_dir: Path, table: str, remap: dict[int, int], batch_size
     rows = data.select(cols).to_pylist()
     remapped = 0
     for row in rows:
-        if 'company_id' in row and row['company_id'] in remap:
+        if 'company_id' in row:
+            # An id missing from the remap must stop the load, never pass through: the snapshot's
+            # company ids mean nothing in the target, so keeping one files this agency's mail under
+            # whichever company happens to hold that id now — silent, and invisible afterwards.
+            if row['company_id'] not in remap:
+                sys.exit(
+                    f'{table}: company_id {row["company_id"]} has no mapping to a current company. '
+                    'Nothing has been written. This means the snapshot companies table and the rows '
+                    'disagree, which should not happen — do not bypass it.'
+                )
             row['company_id'] = remap[row['company_id']]
             remapped += 1
         buf.write('\t'.join(pg_text(row[c]) for c in cols) + '\n')
@@ -222,7 +298,13 @@ def pg_text(v) -> str:
 
 
 def rollback(cur, input_dir: Path, batch_size: int) -> None:
-    """Delete exactly the restored ids, children first."""
+    """Delete exactly the restored ids, children first.
+
+    Deleting every id in the parquet is only the same thing as "undo the restore" because the load
+    refuses to start when the target already holds any of them (check_target_clean). That guarantee
+    is what makes this safe without a manifest: nothing here can remove a row the restore did not
+    write. If that pre-flight is ever bypassed, this is no longer true and could delete live rows.
+    """
     for table in reversed(TABLES):
         ids = read_table(input_dir, table, ['id'])['id'].to_pylist()
         deleted = 0
@@ -253,8 +335,9 @@ def main() -> None:
         log('rollback committed')
         return
 
-    log('checking sequences')
+    log('pre-flight')
     check_sequences(cur, args.input, args.allow_id_overlap)
+    check_target_clean(cur, args.input)
 
     remap = company_remap(cur, args.input)
     log(f'company remap: {", ".join(f"{o}->{n}" for o, n in sorted(remap.items()))}')

--- a/tests/test_load_recovered.py
+++ b/tests/test_load_recovered.py
@@ -118,3 +118,51 @@ class TestPositiveInt:
 
     def test_accepts_a_positive_value(self):
         assert load_recovered.positive_int('5000') == 5000
+
+
+class TestReadRows:
+    """--start/--end are whole days. Route A needs a sub-day cut: a subaccount restored from a
+    nightly snapshot was deleted some hours later the same day, so only the sends between the
+    snapshot and the deletion come from Route B. Loading the whole day would also insert the sends
+    made *after* the deletion, which already exist in the database as real messages."""
+
+    @staticmethod
+    def _write(tmp_path, rows):
+        import csv
+        import gzip
+
+        path = tmp_path / '2026-08-26.csv.gz'
+        with gzip.open(path, 'wt', newline='', encoding='utf-8') as fh:
+            w = csv.DictWriter(fh, fieldnames=list(rows[0]))
+            w.writeheader()
+            w.writerows(rows)
+        return tmp_path
+
+    def test_start_ts_and_end_ts_cut_within_a_day(self, tmp_path):
+        rows = [
+            row('2026-08-26T00:30:00.000000', code='agency-a'),  # before the snapshot
+            row('2026-08-26T01:32:43.507000', code='agency-a'),  # in the window
+            row('2026-08-26T19:00:00.000000', code='agency-a'),  # in the window
+            row('2026-08-26T22:39:09.472000', code='agency-a'),  # after the deletion
+        ]
+        d = self._write(tmp_path, rows)
+
+        got = list(
+            load_recovered.read_rows(
+                d,
+                'agency-a',
+                None,
+                None,
+                start_ts='2026-08-26T01:06:00',
+                end_ts='2026-08-26T19:48:37',
+            )
+        )
+        assert [r['send_ts'] for r in got] == ['2026-08-26T01:32:43.507000', '2026-08-26T19:00:00.000000']
+
+    def test_no_ts_bounds_returns_the_whole_day(self, tmp_path):
+        rows = [
+            row('2026-08-26T00:30:00.000000', code='agency-a'),
+            row('2026-08-26T22:39:09.472000', code='agency-a'),
+        ]
+        d = self._write(tmp_path, rows)
+        assert len(list(load_recovered.read_rows(d, 'agency-a', None, None))) == 2

--- a/tests/test_load_recovered.py
+++ b/tests/test_load_recovered.py
@@ -1,0 +1,120 @@
+"""Unit tests for the recovery loader's pure helpers (scripts/load_recovered.py).
+
+The script is run by hand against a --dsn and is never imported by the app, so it is loaded here by
+path. Only the logic that decides *what* gets written is covered: a mistake in these three helpers
+writes duplicate or mis-homed email history into production, which is exactly what the loader exists
+to avoid.
+"""
+
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).parent.parent / 'scripts' / 'load_recovered.py'
+_spec = importlib.util.spec_from_file_location('load_recovered', _SCRIPT)
+load_recovered = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(load_recovered)
+
+
+def row(send_ts, to_address='a@example.com', group_uuid='', code='agency', branch='1', subject='Reminder'):
+    return {
+        'send_ts': send_ts,
+        'to_address': to_address,
+        'group_uuid': group_uuid,
+        'company_code': code,
+        'branch_id': branch,
+        'subject': subject,
+    }
+
+
+class TestDedupeRows:
+    """The SQL insert guard cannot see rows inserted by its own statement, so identical rows inside
+    one --batch-size chunk would both land. dedupe_rows is what stops that."""
+
+    def test_collapses_rows_identical_on_group_address_and_send_ts(self):
+        u = '11111111-1111-1111-1111-111111111111'
+        rows = [row('2025-09-02T13:43:19+00:00', group_uuid=u)] * 5
+        assert len(load_recovered.dedupe_rows(rows)) == 1
+
+    def test_collapses_even_when_the_subject_differs(self):
+        # The key deliberately excludes subject, matching the SQL guard. Keeping both copies here
+        # would mean the guard and the python pass disagree about what a duplicate is.
+        u = '11111111-1111-1111-1111-111111111111'
+        rows = [
+            row('2025-09-02T13:43:19+00:00', group_uuid=u, subject='One'),
+            row('2025-09-02T13:43:19+00:00', group_uuid=u, subject='Two'),
+        ]
+        assert len(load_recovered.dedupe_rows(rows)) == 1
+
+    def test_keeps_rows_differing_on_any_part_of_the_key(self):
+        u = '11111111-1111-1111-1111-111111111111'
+        v = '22222222-2222-2222-2222-222222222222'
+        rows = [
+            row('2025-09-02T13:43:19+00:00', group_uuid=u),
+            row('2025-09-02T13:43:20+00:00', group_uuid=u),  # different second
+            row('2025-09-02T13:43:19+00:00', to_address='b@example.com', group_uuid=u),
+            row('2025-09-02T13:43:19+00:00', group_uuid=v),  # different group
+        ]
+        assert len(load_recovered.dedupe_rows(rows)) == 4
+
+    def test_dedupes_rows_whose_group_is_synthesised(self):
+        # No group_uuid: the group is derived from code + branch + minute, so two sends in the same
+        # minute share a group and must still be compared on their exact send_ts.
+        rows = [
+            row('2025-09-02T13:43:19+00:00'),
+            row('2025-09-02T13:43:19+00:00'),
+            row('2025-09-02T13:43:45+00:00'),  # same synthesised group, different second
+        ]
+        assert len(load_recovered.dedupe_rows(rows)) == 2
+
+    def test_does_not_merge_synthesised_groups_across_branches(self):
+        rows = [
+            row('2025-09-02T13:43:19+00:00', branch='1'),
+            row('2025-09-02T13:43:19+00:00', branch='2'),
+        ]
+        assert len(load_recovered.dedupe_rows(rows)) == 2
+
+    def test_keeps_the_first_occurrence_and_preserves_order(self):
+        u = '11111111-1111-1111-1111-111111111111'
+        rows = [
+            row('2025-09-02T13:00:00+00:00', group_uuid=u, subject='first'),
+            row('2025-09-02T13:00:00+00:00', group_uuid=u, subject='second'),
+            row('2025-09-02T14:00:00+00:00', group_uuid=u, subject='third'),
+        ]
+        assert [r['subject'] for r in load_recovered.dedupe_rows(rows)] == ['first', 'third']
+
+    def test_returns_input_unchanged_when_there_are_no_duplicates(self):
+        rows = [row('2025-09-02T13:00:00+00:00'), row('2025-09-02T14:00:00+00:00')]
+        assert load_recovered.dedupe_rows(rows) == rows
+
+
+class TestExistingGroupConflicts:
+    """A group_uuid already in the database is reused as-is, but messages.company_id comes from the
+    CSV row. If those disagree the load writes one agency's mail under another agency's group."""
+
+    def test_no_conflict_when_the_existing_group_matches(self):
+        groups = {'u1': {'code': 'agency:1'}}
+        assert load_recovered.existing_group_conflicts(groups, {'u1': 7}, {'agency:1': 7}) == []
+
+    def test_reports_a_group_owned_by_a_different_company(self):
+        groups = {'u1': {'code': 'agency:1'}}
+        conflicts = load_recovered.existing_group_conflicts(groups, {'u1': 9}, {'agency:1': 7})
+        assert conflicts == [('u1', 9, 7)]
+
+    def test_ignores_groups_that_do_not_exist_yet(self):
+        groups = {'u1': {'code': 'agency:1'}}
+        assert load_recovered.existing_group_conflicts(groups, {}, {'agency:1': 7}) == []
+
+
+class TestPositiveInt:
+    """--batch-size 0 makes `limit 0` delete nothing from staging, so the insert loop never ends."""
+
+    @pytest.mark.parametrize('value', ['0', '-1'])
+    def test_rejects_values_below_one(self, value):
+        with pytest.raises(argparse.ArgumentTypeError):
+            load_recovered.positive_int(value)
+
+    def test_accepts_a_positive_value(self):
+        assert load_recovered.positive_int('5000') == 5000

--- a/tests/test_load_recovered.py
+++ b/tests/test_load_recovered.py
@@ -53,7 +53,9 @@ class TestDedupeRows:
         v = '22222222-2222-2222-2222-222222222222'
         rows = [
             row('2025-09-02T13:43:19+00:00', group_uuid=u),
-            row('2025-09-02T13:43:20+00:00', group_uuid=u),  # different second
+            # Comfortably outside the dedupe window: a second's difference now reads as the same
+            # email logged by two sources, which is what p90 of the near-duplicate pairs looks like.
+            row('2025-09-02T13:43:49+00:00', group_uuid=u),
             row('2025-09-02T13:43:19+00:00', to_address='b@example.com', group_uuid=u),
             row('2025-09-02T13:43:19+00:00', group_uuid=v),  # different group
         ]
@@ -166,3 +168,319 @@ class TestReadRows:
         ]
         d = self._write(tmp_path, rows)
         assert len(list(load_recovered.read_rows(d, 'agency-a', None, None))) == 2
+
+
+class TestDedupeWindow:
+    """The rendered files were merged from two sources (papertrail + bigquery) whose clocks differ,
+    so the same email can appear twice a few milliseconds apart. dedupe_rows' exact key collapses
+    38,383 identical pairs but misses 6,930 near-identical ones, which would then be written twice.
+    The window is what closes that, and it must match the SQL guard's -- see TestInsertGuardWindow."""
+
+    U = '11111111-1111-1111-1111-111111111111'
+
+    def test_collapses_rows_a_few_milliseconds_apart(self):
+        rows = [
+            row('2026-08-26T01:32:43.507000', group_uuid=self.U),
+            row('2026-08-26T01:32:43.550000', group_uuid=self.U),
+        ]
+        assert len(load_recovered.dedupe_rows(rows, window_seconds=5)) == 1
+
+    def test_keeps_rows_further_apart_than_the_window(self):
+        rows = [
+            row('2026-08-26T01:32:43.507000', group_uuid=self.U),
+            row('2026-08-26T01:32:52.000000', group_uuid=self.U),
+        ]
+        assert len(load_recovered.dedupe_rows(rows, window_seconds=5)) == 2
+
+    def test_window_zero_keeps_the_old_exact_behaviour(self):
+        rows = [
+            row('2026-08-26T01:32:43.507000', group_uuid=self.U),
+            row('2026-08-26T01:32:43.550000', group_uuid=self.U),
+        ]
+        assert len(load_recovered.dedupe_rows(rows, window_seconds=0)) == 2
+
+    def test_window_does_not_merge_different_addresses_or_groups(self):
+        rows = [
+            row('2026-08-26T01:32:43.507000', group_uuid=self.U, to_address='a@example.com'),
+            row('2026-08-26T01:32:43.510000', group_uuid=self.U, to_address='b@example.com'),
+            row('2026-08-26T01:32:43.512000', group_uuid='22222222-2222-2222-2222-222222222222'),
+        ]
+        assert len(load_recovered.dedupe_rows(rows, window_seconds=5)) == 3
+
+    def test_the_window_is_measured_from_the_row_that_was_kept(self):
+        # Anchoring on the last *kept* row rather than the previous row stops a long run of sends a
+        # few seconds apart from chaining into one, which would swallow genuinely distinct email.
+        rows = [
+            row('2026-08-26T01:00:00', group_uuid=self.U),
+            row('2026-08-26T01:00:04', group_uuid=self.U),
+            row('2026-08-26T01:00:08', group_uuid=self.U),
+        ]
+        kept = load_recovered.dedupe_rows(rows, window_seconds=5)
+        assert [r['send_ts'] for r in kept] == ['2026-08-26T01:00:00', '2026-08-26T01:00:08']
+
+    def test_offset_aware_and_naive_timestamps_compare_as_utc(self):
+        # read_rows compares send_ts as strings, so both shapes reach here; a naive value is UTC.
+        rows = [
+            row('2026-08-26T01:32:43.507000', group_uuid=self.U),
+            row('2026-08-26T01:32:43.550000+00:00', group_uuid=self.U),
+        ]
+        assert len(load_recovered.dedupe_rows(rows, window_seconds=5)) == 1
+
+
+class TestInsertGuardWindow:
+    """The SQL guard is what stops the loader re-inserting email the database already holds.
+
+    It matched on an exact send_ts, but Route B's send_ts comes from a log line while the database's
+    was set by the app, so they never agree to the microsecond. Every agency kept sending after its
+    own subaccount was deleted, and the rendered files carry those post-deletion sends too -- so an
+    exact match re-inserts, as reconstructions, thousands of emails that are still live in
+    production. This runs the loader against a real database to prove the window closes that.
+
+    No real agency codes or addresses appear here; the fixtures are invented.
+    """
+
+    GROUP = '33333333-3333-3333-3333-333333333333'
+    ADDRESS = 'someone@example.com'
+
+    @staticmethod
+    def _rendered(tmp_path, send_ts, group_uuid, to_address):
+        import csv
+        import gzip
+
+        path = tmp_path / '2026-08-26.csv.gz'
+        fields = [
+            'send_ts',
+            'company_code',
+            'branch_id',
+            'group_uuid',
+            'to_address',
+            'first_name',
+            'last_name',
+            'user_id',
+            'role_type',
+            'trigger',
+            'tags',
+            'subject',
+            'body',
+            'from_address',
+            'reply_to',
+            'sources',
+            'context_keys',
+        ]
+        with gzip.open(path, 'wt', newline='', encoding='utf-8') as fh:
+            w = csv.DictWriter(fh, fieldnames=fields)
+            w.writeheader()
+            w.writerow(
+                {
+                    'send_ts': send_ts,
+                    'company_code': 'agency-a',
+                    'branch_id': '1',
+                    'group_uuid': group_uuid,
+                    'to_address': to_address,
+                    'first_name': 'Sam',
+                    'last_name': 'Jones',
+                    'user_id': '',
+                    'role_type': '',
+                    'trigger': 'reminder',
+                    'tags': '[]',
+                    'subject': 'Reminder',
+                    'body': '<p>body</p>',
+                    'from_address': 'from@example.com',
+                    'reply_to': '',
+                    'sources': '{}',
+                    'context_keys': '[]',
+                }
+            )
+        return tmp_path
+
+    @staticmethod
+    def _seed_real_send(cur, group_uuid, address, send_ts):
+        """A send the agency made after its deletion: still live, so the loader must not re-add it."""
+        cur.execute("insert into companies (code) values ('agency-a:1') returning id")
+        company_id = cur.fetchone()[0]
+        cur.execute(
+            """insert into message_groups (uuid, company_id, message_method, created_ts)
+               values (%s, %s, 'email-mandrill', %s) returning id""",
+            (group_uuid, company_id, send_ts),
+        )
+        group_id = cur.fetchone()[0]
+        cur.execute(
+            """insert into messages (group_id, company_id, method, send_ts, update_ts, status, to_address, subject, body)
+               values (%s, %s, 'email-mandrill', %s, %s, 'send', %s, 'Reminder', '<p>body</p>')""",
+            (group_id, company_id, send_ts, send_ts, address),
+        )
+
+    def _args(self, tmp_path, window):
+        return argparse.Namespace(
+            input=tmp_path,
+            agency='agency-a',
+            batch_id='test-batch',
+            start=None,
+            end=None,
+            start_ts=None,
+            end_ts=None,
+            as_code=None,
+            batch_size=5000,
+            method='email-mandrill',
+            dry_run=False,
+            dedupe_window=window,
+        )
+
+    def _run(self, tmp_path, window):
+        import psycopg2
+
+        from app.core.config import settings
+
+        # The loader takes a raw psycopg2 connection and a --dsn, exactly as it is run by hand.
+        conn = psycopg2.connect(settings.database_url)
+        conn.autocommit = False
+        cur = conn.cursor()
+        try:
+            self._seed_real_send(cur, self.GROUP, self.ADDRESS, '2026-08-26T22:39:09.472000+00:00')
+            conn.commit()
+            # 90ms earlier than the database's row: the same email, logged by a different clock.
+            d = self._rendered(tmp_path, '2026-08-26T22:39:09.382000', self.GROUP, self.ADDRESS)
+            load_recovered.load(conn, cur, self._args(d, window))
+            cur.execute('select count(*) from messages')
+            return cur.fetchone()[0]
+        finally:
+            conn.close()
+
+    def test_a_near_match_is_recognised_as_already_present(self, db):
+        assert self._run(self.tmp, 5) == 1
+
+    def test_without_a_window_the_live_email_is_duplicated(self, db):
+        # Documents the behaviour being fixed: an exact match never fires, so the row goes in twice.
+        assert self._run(self.tmp, 0) == 2
+
+    @pytest.fixture(autouse=True)
+    def _tmp(self, tmp_path):
+        self.tmp = tmp_path
+
+
+class TestMajorityOwner:
+    """54 group uuids appear under two different agencies, covering 2,202 rows of which 117 are the
+    odd ones out. The loader refuses to reuse a group whose company is not the one its rows claim
+    (existing_group_conflicts), so those 117 rows block 8 of the 25 agency loads outright -- 240,759
+    messages, 68% of the recovery, stopped by 33 rows.
+
+    Whoever loads first must not simply win the uuid: with the runbook's order that would re-home
+    1,315 of one agency's rows into another's group. The owner is decided once, from the whole input,
+    before any load -- the majority holder keeps the uuid and the minority rows are synthesised into
+    their own group, which is what they should have had.
+    """
+
+    @staticmethod
+    def _write(tmp_path, name, rows):
+        import csv
+        import gzip
+
+        fields = ['send_ts', 'company_code', 'branch_id', 'group_uuid', 'to_address']
+        with gzip.open(tmp_path / name, 'wt', newline='', encoding='utf-8') as fh:
+            w = csv.DictWriter(fh, fieldnames=fields, extrasaction='ignore')
+            w.writeheader()
+            w.writerows(rows)
+        return tmp_path
+
+    U = '44444444-4444-4444-4444-444444444444'
+
+    def test_only_shared_uuids_are_reported(self, tmp_path):
+        d = self._write(
+            tmp_path,
+            '2026-08-26.csv.gz',
+            [
+                row('2026-08-26T01:00:00', group_uuid=self.U, code='agency-a'),
+                row('2026-08-26T01:00:01', group_uuid='55555555-5555-5555-5555-555555555555', code='agency-b'),
+            ],
+        )
+        assert load_recovered.majority_owner(d) == {}
+
+    def test_the_code_with_the_most_rows_keeps_the_uuid(self, tmp_path):
+        d = self._write(
+            tmp_path,
+            '2026-08-26.csv.gz',
+            [
+                row('2026-08-26T01:00:00', group_uuid=self.U, code='agency-a'),
+                row('2026-08-26T01:00:01', group_uuid=self.U, code='agency-a'),
+                row('2026-08-26T01:00:02', group_uuid=self.U, code='agency-b'),
+            ],
+        )
+        assert load_recovered.majority_owner(d) == {self.U: 'agency-a:1'}
+
+    def test_a_tie_is_broken_deterministically(self, tmp_path):
+        d = self._write(
+            tmp_path,
+            '2026-08-26.csv.gz',
+            [
+                row('2026-08-26T01:00:00', group_uuid=self.U, code='agency-z'),
+                row('2026-08-26T01:00:01', group_uuid=self.U, code='agency-a'),
+            ],
+        )
+        assert load_recovered.majority_owner(d) == {self.U: 'agency-a:1'}
+
+    def test_the_scan_covers_every_day_not_just_the_loaded_range(self, tmp_path):
+        # --start-ts/--end-ts must not change who owns a uuid, or the Route A tail run would
+        # disagree with the main load about which rows are the minority.
+        self._write(tmp_path, '2026-08-26.csv.gz', [row('2026-08-26T01:00:00', group_uuid=self.U, code='agency-b')])
+        d = self._write(
+            tmp_path,
+            '2026-08-27.csv.gz',
+            [
+                row('2026-08-27T01:00:00', group_uuid=self.U, code='agency-a'),
+                row('2026-08-27T01:00:01', group_uuid=self.U, code='agency-a'),
+            ],
+        )
+        assert load_recovered.majority_owner(d) == {self.U: 'agency-a:1'}
+
+
+class TestGroupUuidForWithOwners:
+    U = '44444444-4444-4444-4444-444444444444'
+
+    def test_the_majority_keeps_the_real_uuid(self):
+        r = row('2026-08-26T01:00:00', group_uuid=self.U, code='agency-a')
+        assert load_recovered.group_uuid_for(r, {self.U: 'agency-a:1'}) == self.U
+
+    def test_the_minority_is_synthesised_into_its_own_group(self):
+        r = row('2026-08-26T01:00:00', group_uuid=self.U, code='agency-b')
+        got = load_recovered.group_uuid_for(r, {self.U: 'agency-a:1'})
+        assert got != self.U
+        # identical to the path a row with no uuid at all takes
+        assert got == load_recovered.group_uuid_for(dict(r, group_uuid=''))
+
+    def test_two_minority_agencies_do_not_land_in_the_same_group(self):
+        owners = {self.U: 'agency-a:1'}
+        b = load_recovered.group_uuid_for(row('2026-08-26T01:00:00', group_uuid=self.U, code='agency-b'), owners)
+        c = load_recovered.group_uuid_for(row('2026-08-26T01:00:00', group_uuid=self.U, code='agency-c'), owners)
+        assert b != c
+
+    def test_no_owner_map_leaves_every_uuid_alone(self):
+        r = row('2026-08-26T01:00:00', group_uuid=self.U, code='agency-b')
+        assert load_recovered.group_uuid_for(r) == self.U
+
+
+class TestDbOwnersWin:
+    """A uuid can be shared with a group that is already in the database rather than with another
+    rendered agency -- the snapshot restore brings in 57,705 real groups, one of which a
+    reconstructed agency also carries. Scanning the rendered files cannot see that, so what the database already holds is merged
+    in on top, and it wins: those rows are real, already-written email.
+    """
+
+    U = '66666666-6666-6666-6666-666666666666'
+    V = '77777777-7777-7777-7777-777777777777'
+
+    def test_the_database_overrides_the_rendered_majority(self):
+        merged = load_recovered.merge_db_owners({self.U: 'agency-a:1'}, {self.U: 'prime:30784'})
+        assert merged == {self.U: 'prime:30784'}
+
+    def test_a_uuid_only_the_database_knows_about_is_added(self):
+        merged = load_recovered.merge_db_owners({}, {self.V: 'prime:30784'})
+        assert merged == {self.V: 'prime:30784'}
+
+    def test_rendered_ownership_survives_where_the_database_is_silent(self):
+        merged = load_recovered.merge_db_owners({self.U: 'agency-a:1'}, {})
+        assert merged == {self.U: 'agency-a:1'}
+
+    def test_a_row_whose_uuid_the_database_gives_to_another_agency_is_synthesised(self):
+        owners = load_recovered.merge_db_owners({}, {self.U: 'prime:30784'})
+        r = row('2026-08-26T01:00:00', group_uuid=self.U, code='agency-a')
+        assert load_recovered.group_uuid_for(r, owners) != self.U

--- a/tests/test_restore_from_snapshot.py
+++ b/tests/test_restore_from_snapshot.py
@@ -137,3 +137,40 @@ class TestConstants:
     def test_vector_is_never_inserted(self):
         # The create_tsvector BEFORE INSERT trigger rebuilds it, as it does for a normal send.
         assert 'vector' in restore.SKIP_COLUMNS
+
+
+class TestPreflightProblems:
+    """Both hazards must stop the load before a row is written, not partway through.
+
+    The id check is also load-bearing for --rollback: it deletes every id in the parquet, which only
+    means "undo the restore" while the target held none of them beforehand."""
+
+    def test_clean_target_is_go(self):
+        assert restore.preflight_problems({t: 0 for t in restore.TABLES}, []) == []
+
+    def test_ids_already_present_stop_the_load(self):
+        problems = restore.preflight_problems({'messages': 12, 'events': 0}, [])
+        assert len(problems) == 1
+        assert 'messages' in problems[0] and '12' in problems[0]
+
+    def test_every_offending_table_is_named(self):
+        problems = restore.preflight_problems({'messages': 3, 'events': 5, 'links': 0}, [])
+        assert len(problems) == 2
+
+    def test_uuid_under_a_different_id_stops_the_load(self):
+        # ON CONFLICT (id) does not arbitrate the unique index on message_groups.uuid, so this would
+        # otherwise abort the transaction on a bare duplicate-key error.
+        problems = restore.preflight_problems({}, [('uuid-1', 500, 900)])
+        assert len(problems) == 1
+        assert 'uuid-1' in problems[0] and '500' in problems[0] and '900' in problems[0]
+
+    def test_many_uuid_conflicts_are_counted_not_all_printed(self):
+        conflicts = [(f'uuid-{i}', i, i + 1000) for i in range(50)]
+        problems = restore.preflight_problems({}, conflicts)
+        assert '50' in problems[0]
+        assert problems[0].endswith('…')
+
+    def test_both_hazards_reported_together(self):
+        # One run should tell you everything that is wrong, not make you fix them one at a time.
+        problems = restore.preflight_problems({'messages': 4}, [('uuid-1', 1, 2)])
+        assert len(problems) == 2

--- a/tests/test_restore_from_snapshot.py
+++ b/tests/test_restore_from_snapshot.py
@@ -1,0 +1,139 @@
+"""Unit tests for the snapshot restore's pure helpers (scripts/restore_from_snapshot.py).
+
+Companion to test_load_recovered.py, and the same rule applies: the script is run by hand against a
+--dsn and is never imported by the app, so it is loaded here by path, and only the logic that decides
+*what* gets written is covered. A mistake in these three helpers files one agency's mail under
+another, corrupts every body that contains a tab or a newline, or restores primary keys the database
+is about to hand out again.
+
+No real agency codes, addresses or ids appear here; the fixtures are invented.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / 'scripts' / 'restore_from_snapshot.py'
+_spec = importlib.util.spec_from_file_location('restore_from_snapshot', _SCRIPT)
+restore = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(restore)
+
+
+class TestResolveRemap:
+    """company_id is the only field the restore rewrites. The snapshot's companies rows were deleted
+    and re-created by later sends under the same codes with different ids, so the mapping is by code
+    -- and a wrong mapping silently files one agency's email history under another agency."""
+
+    def test_maps_snapshot_ids_to_current_ids_by_code(self):
+        mapping, problems = restore.resolve_remap(
+            {11: 'agency-a:1', 12: 'agency-a:2', 13: 'agency-b:3'},
+            [11, 12, 13],
+            {'agency-a:1': 900, 'agency-a:2': 901, 'agency-b:3': 902, 'someone-else:9': 903},
+        )
+        assert mapping == {11: 900, 12: 901, 13: 902}
+        assert problems == []
+
+    def test_ids_are_not_carried_over_when_they_happen_to_match(self):
+        # The snapshot id and the current id for a code are unrelated numbers. A remap that quietly
+        # kept the old id would look correct here only by coincidence.
+        mapping, _ = restore.resolve_remap({11: 'agency-a:1'}, [11], {'agency-a:1': 11})
+        assert mapping == {11: 11}
+        mapping, _ = restore.resolve_remap({11: 'agency-a:1'}, [11], {'agency-a:1': 4242})
+        assert mapping == {11: 4242}
+
+    def test_code_missing_from_the_target_is_a_problem_not_a_silent_skip(self):
+        mapping, problems = restore.resolve_remap(
+            {11: 'agency-a:1', 12: 'agency-a:2'}, [11, 12], {'agency-a:1': 900}
+        )
+        assert mapping == {11: 900}
+        assert len(problems) == 1
+        assert 'agency-a:2' in problems[0]
+
+    def test_id_missing_from_the_snapshot_companies_table_is_a_problem(self):
+        _, problems = restore.resolve_remap({11: 'agency-a:1'}, [11, 99], {'agency-a:1': 900})
+        assert len(problems) == 1
+        assert '99' in problems[0]
+
+    def test_only_the_ids_actually_used_need_resolving(self):
+        # A branch that exists but sent nothing has no rows to remap, so its absence from the target
+        # must not block the load.
+        mapping, problems = restore.resolve_remap(
+            {11: 'agency-a:1', 12: 'agency-a:never-sent'}, [11], {'agency-a:1': 900}
+        )
+        assert mapping == {11: 900}
+        assert problems == []
+
+
+class TestSequenceProblems:
+    """Restoring original primary keys is only safe while every one sits below its sequence. If one
+    reaches it, the database is about to hand that id out again to a different row."""
+
+    def test_ids_below_the_sequence_are_fine(self):
+        assert restore.sequence_problems({'messages': 100}, {'messages': 101}) == []
+
+    def test_id_equal_to_the_sequence_is_a_problem(self):
+        # last_value is the id most recently handed out, so an equal id is already taken.
+        assert len(restore.sequence_problems({'messages': 100}, {'messages': 100})) == 1
+
+    def test_id_past_the_sequence_is_a_problem(self):
+        problems = restore.sequence_problems({'messages': 500}, {'messages': 100})
+        assert len(problems) == 1
+        assert 'messages' in problems[0]
+
+    def test_reports_every_offending_table_not_just_the_first(self):
+        problems = restore.sequence_problems(
+            {'message_groups': 1, 'messages': 500, 'events': 900, 'links': 2},
+            {'message_groups': 10, 'messages': 100, 'events': 90, 'links': 20},
+        )
+        assert len(problems) == 2
+        assert {p.split(':')[0] for p in problems} == {'messages', 'events'}
+
+
+class TestPgText:
+    """Values are handed to COPY as text. Email bodies are HTML full of newlines, and a tag can hold
+    a tab, so an unescaped character ends the row or the field early and shifts every column after
+    it -- which COPY accepts happily until the types stop lining up."""
+
+    def test_none_becomes_the_null_marker(self):
+        # \\N is COPY's NULL, distinct from the two-character string 'N' or an empty field.
+        assert restore.pg_text(None) == '\\N'
+
+    def test_booleans_use_the_postgres_short_forms(self):
+        assert restore.pg_text(True) == 't'
+        assert restore.pg_text(False) == 'f'
+
+    def test_empty_string_is_not_null(self):
+        assert restore.pg_text('') == ''
+
+    def test_newline_would_otherwise_end_the_row(self):
+        assert restore.pg_text('line one\nline two') == 'line one\\nline two'
+
+    def test_tab_would_otherwise_end_the_field(self):
+        assert restore.pg_text('a\tb') == 'a\\tb'
+
+    def test_carriage_return_is_escaped(self):
+        assert restore.pg_text('a\r\nb') == 'a\\r\\nb'
+
+    def test_backslash_is_escaped_first(self):
+        # Escaping the backslash after the others would turn an escape sequence we just wrote into a
+        # literal backslash plus 'n', so ordering is the whole game here.
+        assert restore.pg_text('a\\nb') == 'a\\\\nb'
+        assert restore.pg_text('back\\slash\nnewline') == 'back\\\\slash\\nnewline'
+
+    def test_html_body_survives_intact(self):
+        body = '<p>Hi</p>\n<a href="https://example.com/x?a=1&b=2">Link</a>\n'
+        assert restore.pg_text(body) == body.replace('\n', '\\n')
+
+    def test_numbers_and_arrays_are_stringified(self):
+        assert restore.pg_text(0) == '0'
+        assert restore.pg_text(1.5) == '1.5'
+        assert restore.pg_text('{tag-one,tag-two}') == '{tag-one,tag-two}'
+
+
+class TestConstants:
+    def test_tables_are_in_foreign_key_order(self):
+        # Each table points at the one before it, so any other order fails on insert.
+        assert restore.TABLES == ['message_groups', 'messages', 'events', 'links']
+
+    def test_vector_is_never_inserted(self):
+        # The create_tsvector BEFORE INSERT trigger rebuilds it, as it does for a normal send.
+        assert 'vector' in restore.SKIP_COLUMNS

--- a/tests/test_restore_from_snapshot.py
+++ b/tests/test_restore_from_snapshot.py
@@ -41,9 +41,7 @@ class TestResolveRemap:
         assert mapping == {11: 4242}
 
     def test_code_missing_from_the_target_is_a_problem_not_a_silent_skip(self):
-        mapping, problems = restore.resolve_remap(
-            {11: 'agency-a:1', 12: 'agency-a:2'}, [11, 12], {'agency-a:1': 900}
-        )
+        mapping, problems = restore.resolve_remap({11: 'agency-a:1', 12: 'agency-a:2'}, [11, 12], {'agency-a:1': 900})
         assert mapping == {11: 900}
         assert len(problems) == 1
         assert 'agency-a:2' in problems[0]


### PR DESCRIPTION
Adds `scripts/load_recovered.py`, a standalone CLI that loads the email records reconstructed for #548 back into a Morpheus database — it is run by hand against a `--dsn`, is not imported by the app, and is never deployed. Every inserted row is stamped `extra.recovered_batch` so a load can be undone with `--rollback`, `--dry-run` performs the entire load inside a transaction and rolls it back, and rows already present for the same group, address and send time are skipped rather than duplicated. No recovered data is included in this PR — the rendered files stay local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)